### PR TITLE
Edit SHA512.saw to support more parameters.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src"]
 	path = src
-	url = git@github.com:awslabs/aws-lc.git
+	url = https://github.com/awslabs/aws-lc.git
 	branch = main
 [submodule "cryptol-specs"]
 	path = cryptol-specs

--- a/SAW/proof/SHA512/SHA512-384-check-entrypoint.go
+++ b/SAW/proof/SHA512/SHA512-384-check-entrypoint.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// A utility function to terminate this program when err exists.
+func checkError(e error) {
+	if e != nil {
+		log.Fatal(e)
+	}
+}
+
+// A function to create and run "verify-SHA512-384-check.saw" given a "target_num".
+func createAndRunSawScript(target_num int, wg *sync.WaitGroup) {
+	log.Printf("Start creating saw script for selected num %d", target_num)
+	// Create a new saw script for the target_num.
+	file_name := fmt.Sprint("verify-SHA512-384-check-num-", target_num, ".saw")
+	file, err := os.Create(file_name)
+	checkError(err)
+	// Read file content of verification template.
+	content, err := ioutil.ReadFile("verify-SHA512-384-selectcheck-template.txt")
+	checkError(err)
+	verification_template := string(content)
+	// Replace some placeholders of the file content with target values.
+	text := strings.Replace(verification_template, "TARGET_NUM_PLACEHOLDER", strconv.Itoa(target_num), 1)
+	defer file.Close()
+	file.WriteString(text)
+	defer os.Remove(file_name)
+	// Run saw script.
+	defer wg.Done()
+	runSawScript(file_name)
+}
+
+// A function to run saw script.
+func runSawScript(path_to_saw_file string) {
+	log.Printf("Running saw script %s", path_to_saw_file)
+	cmd := exec.Command("saw", path_to_saw_file)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	checkError(err)
+}
+
+func main() {
+	log.Printf("Starting SHA512-384 check.")
+	// When 'SHA512_384_SELECTCHECK' is undefined, quickcheck is executed.
+	env_var := os.Getenv("SHA512_384_SELECTCHECK")
+	if len(env_var) == 0 {
+		runSawScript("verify-SHA512-384-quickcheck.saw")
+		return
+	}
+
+	// When 'SHA512_384_SELECTCHECK' is defined, formal verification is executed with all `len` given a 'num'.
+	// Due to memory usage (each select_check takes 8GB memory) and limit of container size (largest one has 145GB memory),
+	// not all nums are used to run formal verification. Only below nums are selected.
+	target_nums := []int{0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 127}
+
+	// Generate saw scripts based on above verification template and target num ranges.
+	var wg sync.WaitGroup
+	for _, num := range target_nums {
+		wg.Add(1)
+		go createAndRunSawScript(num, &wg)
+	}
+
+	wg.Wait()
+	log.Printf("Completed SHA512-384 check.")
+}

--- a/SAW/proof/SHA512/SHA512.saw
+++ b/SAW/proof/SHA512/SHA512.saw
@@ -255,55 +255,35 @@ if quick_check then do {
     (w4_unint_yices ["processBlock_Common"]);
   return ();
 } else do {
-  let verify_update_at_num num = do {
-    print (str_concat "Verifying EVP_DigestUpdate at num=" (show num));
-    if eval_bool {{ `num == 0 }} then do {
-      // this covers the case without any calls to the block
-      // function, and data copied in c->data
-      crucible_llvm_verify m "EVP_DigestUpdate"
+  // this covers the case with all lengths given a target_num.
+  print (str_concat "Verifying EVP_DigestUpdate at target_num=" (show target_num));
+  let verify_update_at_len len = do {
+    print (str_concat "Verifying EVP_DigestUpdate at len=" (show len));
+    crucible_llvm_verify m "EVP_DigestUpdate"
         [sha512_block_data_order_spec]
         true
-        (EVP_DigestUpdate_spec num (eval_size {| SHA512_CBLOCK - 1 |}))
+        (EVP_DigestUpdate_spec target_num len)
         (w4_unint_yices ["processBlock_Common"]);
-      // this covers the case with one call to the block
-      // function, on one block from data, and the rest of
-      // data copied in c->data
-      crucible_llvm_verify m "EVP_DigestUpdate"
-        [sha512_block_data_order_spec]
-        true
-        (EVP_DigestUpdate_spec num (eval_size {| SHA512_CBLOCK + 1 |}))
-        (w4_unint_yices ["processBlock_Common"]);
-    } else do {
-      // this covers the case without any calls to the block
-      // function, and data copied in c->data
-      crucible_llvm_verify m "EVP_DigestUpdate"
-        [sha512_block_data_order_spec]
-        true
-        (EVP_DigestUpdate_spec num (eval_size {| SHA512_CBLOCK - 1 - num |}))
-        (w4_unint_yices ["processBlock_Common"]);
-      // this covers the case with one call to the block
-      // function, on c->data, and the rest of data copied
-      // in c->data
-      crucible_llvm_verify m "EVP_DigestUpdate"
-        [sha512_block_data_order_spec]
-        true
-        (EVP_DigestUpdate_spec num (eval_size {| SHA512_CBLOCK + 1 - num |}))
-        (w4_unint_yices ["processBlock_Common"]);
-      // this covers the case with two calls to the block
-      // function, the first one on c->data, the second one
-      // on one block from data, and the rest of data copied
-      // in c->data
-      crucible_llvm_verify m "EVP_DigestUpdate"
-        [sha512_block_data_order_spec]
-        true
-        (EVP_DigestUpdate_spec num (eval_size {| 2 * SHA512_CBLOCK + 1 - num |}))
-        (w4_unint_yices ["processBlock_Common"]);
-    };
   };
-  for nums verify_update_at_num;
+  // Given a fixed `num`, the `lens` cover all possible parameters especially below cases:
+  // When len = (SHA512_CBLOCK - 1), this covers the case without any calls to the block function, 
+  //   and data copied in c->data.
+  // When len = (SHA512_CBLOCK + 1), this covers the case with one call to the block function, 
+  //   on one block from data, and the rest of data copied in c->data.
+  // When len = (SHA512_CBLOCK + 1), this covers the case with two calls to the block function,
+  //   the first one on c->data,  the second one on one block from data, and the rest of data copied in c->data.
+  // Note: when num = 0, 'len = 256' check fails due to 'sha512_block_data_order' limit. See https://github.com/awslabs/aws-lc-verification/issues/25
+  if eval_bool {{ `target_num == 0 }} then do {
+    lens <- for (eval_list {{ [0 .. (2 * SHA512_CBLOCK - 1)] : [2 * SHA512_CBLOCK][64] }})
+      (\x -> (return (eval_int x)) : (TopLevel Int));
+    for lens verify_update_at_len;
+  } else do {
+    lens <- for (eval_list {{ [0 .. (2 * SHA512_CBLOCK + 1 - target_num)] : [2 * SHA512_CBLOCK + 2 - target_num][64] }})
+      (\x -> (return (eval_int x)) : (TopLevel Int));
+    for lens verify_update_at_len;
+  };
   return ();
 };
-
 
 // Verify the `EVP_DigestFinal` C function satisfies the
 // `EVP_DigestFinal_spec` specification.

--- a/SAW/proof/SHA512/verify-SHA512-384-quickcheck.saw
+++ b/SAW/proof/SHA512/verify-SHA512-384-quickcheck.saw
@@ -6,5 +6,6 @@
 import "../../../cryptol-specs/Primitive/Keyless/Hash/SHA384.cry";
 
 let quick_check = true;
+let target_num = 128;
 include "SHA512-384.saw";
 include "SHA512.saw";

--- a/SAW/proof/SHA512/verify-SHA512-384-selectcheck-template.txt
+++ b/SAW/proof/SHA512/verify-SHA512-384-selectcheck-template.txt
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
 */
 
-
 import "../../../cryptol-specs/Primitive/Keyless/Hash/SHA384.cry";
 
 let quick_check = false;
+let target_num = TARGET_NUM_PLACEHOLDER;
 include "SHA512-384.saw";
 include "SHA512.saw";

--- a/SAW/proof/SHA512/verify-SHA512-512-quickcheck.saw
+++ b/SAW/proof/SHA512/verify-SHA512-512-quickcheck.saw
@@ -6,5 +6,6 @@
 import "../../../cryptol-specs/Primitive/Keyless/Hash/SHA512.cry";
 
 let quick_check = true;
+let target_num = 128;
 include "SHA512-512.saw";
 include "SHA512.saw";

--- a/SAW/scripts/build_x86.sh
+++ b/SAW/scripts/build_x86.sh
@@ -10,6 +10,6 @@ mkdir -p build_src/x86
 cd build_src/x86
 export CC=clang
 export CXX=clang++
-(cd ../../../src/third_party/boringssl; patch -p1 -r - --forward <"$PATCH"/nomuxrsp.patch || true)
+(cd ../../../src; patch -p1 -r - --forward <"$PATCH"/nomuxrsp.patch || true)
 cmake -DCMAKE_BUILD_TYPE=Rel ../../../src
 make

--- a/SAW/scripts/docker_entrypoint.sh
+++ b/SAW/scripts/docker_entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/sh -ex
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-(cd SAW && ./scripts/entrypoint_quickcheck.sh)
+(cd SAW && ./scripts/entrypoint_check.sh)

--- a/SAW/scripts/entrypoint_check.sh
+++ b/SAW/scripts/entrypoint_check.sh
@@ -10,4 +10,4 @@ PATH=/lc/bin:/go/bin:$PATH
 ./scripts/build_x86.sh
 ./scripts/build_llvm.sh
 ./scripts/post_build.sh
-./scripts/quickcheck.sh
+./scripts/run_checks.sh

--- a/SAW/scripts/post_build.sh
+++ b/SAW/scripts/post_build.sh
@@ -7,12 +7,6 @@
 set -e
 
 mkdir -p build/llvm/crypto build/x86/crypto
-if [ -f build_src/llvm/awslc-config.cmake ]
-then
-    cp build_src/llvm/third_party/boringssl/crypto/crypto_test build/llvm/crypto/crypto_test
-    cp build_src/x86/third_party/boringssl/crypto/crypto_test build/x86/crypto/crypto_test
-else
-    cp build_src/llvm/crypto/crypto_test build/llvm/crypto/crypto_test
-    cp build_src/x86/crypto/crypto_test build/x86/crypto/crypto_test
-fi
+cp build_src/llvm/crypto/crypto_test build/llvm/crypto/crypto_test
+cp build_src/x86/crypto/crypto_test build/x86/crypto/crypto_test
 extract-bc build/llvm/crypto/crypto_test

--- a/SAW/scripts/run_checks.sh
+++ b/SAW/scripts/run_checks.sh
@@ -3,11 +3,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 saw proof/SHA256/SHA256.saw
-saw proof/SHA512/verify-SHA512-384-quickcheck.saw
+(cd proof/SHA512 && go run SHA512-384-check-entrypoint.go)
 saw proof/SHA512/verify-SHA512-512-quickcheck.saw
+# TODO: add select check flavors for HMAC-SHA384 and AES-GCM.
 saw proof/HMAC/verify-HMAC-SHA384-quickcheck.saw
 saw proof/AES/verify-AES-GCM.saw
-


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Changes

This PR
* used HTTPS for `aws-lc` clone.
* removed 'third-party/boringssl' because the main of `aws-lc` has moved `boringssl` back to source dir.
* switched `aws-lc` submodule to latest commit.
* changed SHA512.saw to support select parameters (given a `num`, run verification against all lens).

### Tests
* test with quickcheck (see CI).
* test with selectcheck (see CodeBuild links in CryptoAlg-588).