### PR TITLE
Update SAW version

### DIFF
--- a/SAW/proof/AES/AES.saw
+++ b/SAW/proof/AES/AES.saw
@@ -177,10 +177,19 @@ aes_hw_decrypt_in_place_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_t
   });
 
 add_x86_preserved_reg "r11";
-aes_hw_ctr32_encrypt_blocks_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
+llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []
   true
   (aes_hw_ctr32_encrypt_blocks_spec 2)
+  (do {
+    simplify (cryptol_ss ());
+    simplify (addsimps slice_384_thms basic_ss);
+    w4_unint_yices ["AESRound", "AESFinalRound"];
+  });
+aes_hw_ctr32_encrypt_blocks_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
+  []
+  true
+  (aes_hw_ctr32_encrypt_blocks_spec 1)
   (do {
     simplify (cryptol_ss ());
     simplify (addsimps slice_384_thms basic_ss);

--- a/SAW/proof/AES/AES.saw
+++ b/SAW/proof/AES/AES.saw
@@ -108,6 +108,7 @@ let aes_hw_decrypt_in_place_spec = do {
 
 let aes_hw_ctr32_encrypt_blocks_spec len = do {
   let len' = eval_size {| len * AES_BLOCK_SIZE |};
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
 
   (in_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array len' (llvm_int 8));
   out_ptr <- crucible_alloc (llvm_array len' (llvm_int 8));
@@ -119,6 +120,8 @@ let aes_hw_ctr32_encrypt_blocks_spec len = do {
   crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `len : [64] }}), key_ptr, ivec_ptr];
 
   crucible_points_to out_ptr (crucible_term {{ aes_hw_ctr32_encrypt_blocks in_ key ivec }});
+
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
 };
 
 
@@ -173,13 +176,14 @@ aes_hw_decrypt_in_place_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_t
     w4_unint_yices ["AESInvRound", "AESFinalInvRound"];
   });
 
+add_x86_preserved_reg "r11";
 aes_hw_ctr32_encrypt_blocks_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []
   true
-  (aes_hw_ctr32_encrypt_blocks_spec 1)
+  (aes_hw_ctr32_encrypt_blocks_spec 2)
   (do {
     simplify (cryptol_ss ());
     simplify (addsimps slice_384_thms basic_ss);
     w4_unint_yices ["AESRound", "AESFinalRound"];
   });
-
+default_x86_preserved_reg;

--- a/SAW/proof/AES/AES.saw
+++ b/SAW/proof/AES/AES.saw
@@ -176,6 +176,13 @@ aes_hw_decrypt_in_place_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_t
     w4_unint_yices ["AESInvRound", "AESFinalInvRound"];
   });
 
+/*
+When verifying aes_hw_ctr32_encrypt_blocks, the binary analysis must locally
+treat r11 as callee-preserved. This is necessary because this routine saves
+the original stack pointer in r11 and then calls helper routines, preventing
+the binary analysis from inferring that the return address is still on the stack
+when the routine returns. The called helper routines do not modify r11.
+*/
 add_x86_preserved_reg "r11";
 llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []

--- a/SAW/proof/AES/evp-function-specs.saw
+++ b/SAW/proof/AES/evp-function-specs.saw
@@ -43,6 +43,8 @@ let EVP_CipherInit_ex_spec enc = do {
 };
 
 let EVP_CipherUpdate_spec enc gcm_len len = do {
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+
   cipher_ptr <- crucible_alloc_readonly (llvm_struct "struct.evp_cipher_st");
   points_to_evp_cipher_st cipher_ptr;
 

--- a/SAW/scripts/install.sh
+++ b/SAW/scripts/install.sh
@@ -8,7 +8,7 @@ set -e
 
 Z3_URL='https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip'
 YICES_URL='https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz'
-SAW_URL='https://saw.galois.com/builds/nightly/saw-0.6.0.99-2020-12-09-Linux-x86_64.tar.gz'
+SAW_URL='https://saw.galois.com/builds/nightly/saw-0.7.0.99-2021-01-08-Linux-x86_64.tar.gz'
 
 mkdir -p bin deps
 

--- a/SAW/spec/AES/AES-GCM.cry
+++ b/SAW/spec/AES/AES-GCM.cry
@@ -47,11 +47,16 @@ inv_aes_key_from_schedule (init_key, middle_keys, final_key) = join (map reverse
 aes_hw_decrypt : [16][8] -> [32][8] -> [16][8]
 aes_hw_decrypt in key = split (aesDecrypt ((join in), (join key)))
 
-aes_hw_ctr32_encrypt_blocks : [16][8] -> [32][8] -> [16][8] -> [16][8]
-aes_hw_ctr32_encrypt_blocks in key ivec = in ^ enc_ivec
+aes_hw_ctr32_encrypt_blocks_helper : {n} (fin n) => [n][128] -> [32][8] -> [128] -> [n][128]
+aes_hw_ctr32_encrypt_blocks_helper in key ivec = cs
   where
-    enc_ivec = aes_hw_encrypt ivec key
+    cs = [p ^ (join (aes_hw_encrypt (split ctr) key)) | p <- in | ctr <- ctrs]
+    ctrs = [ join ((take`{3} ivec32) # [(ivec32 @ 3) + i]) | i <- [0 ...]]
+    ivec32 = split`{4} ivec
 
+aes_hw_ctr32_encrypt_blocks : {n} (fin n) => [16*n][8] -> [32][8] -> [16][8] -> [16*n][8]
+aes_hw_ctr32_encrypt_blocks in key ivec =
+  split (join (aes_hw_ctr32_encrypt_blocks_helper (split (join in)) key (join ivec)))
 
 /*
  * GCM specifications.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This pull request updates the SAWScript nightly version to include support for the `pinsrd` instruction, which is necessary to verify `aes_hw_ctr32_encrypt_blocks` for `len > 1`.

`aes_hw_ctr32_encrypt_blocks` branches on `len` to specially handle the case where `len = 1`, which we were previously verifying. SAWScript's binary analysis could not identify the `pinsrd` instruction used in the other branch (when `len > 1`), and therefore translated the subsequent instructions in the branch as an "error" primitive. Now that SAWScript has support for `pinsrd`, the rest of the branch is properly translated. However, this has an unfortunate side effect: `aes_hw_ctr32_encrypt_blocks` saves the original stack pointer in `r11`, which is a caller-saved register. The newly-translated branch contains calls to helper routines (e.g. to `.Lenc_loop8_enter`). Although these helper routines do not overwrite `r11`, this situation prevents the analysis from identifying the return at the end of the routine. Locally treating `r11` as callee-saved fixes this.

We've updated the specification for `aes_hw_ctr32_encrypt_blocks` to deal with the above, using a slightly modified version of the multi-block specification from the `aes-saw` branch.
