### PR TITLE
Removing references to block_mask from the spec.

### DIFF
--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -97,7 +97,6 @@ let points_to_evp_cipher_ctx_st ptr cipher_ptr cipher_data_ptr enc = do {
   crucible_points_to (crucible_field ptr "flags") (crucible_term {{ 0 : [32] }});
   crucible_points_to (crucible_field ptr "buf_len") (crucible_term {{ 0 : [32] }});
   crucible_points_to (crucible_field ptr "final_used") (crucible_term {{ 0 : [32] }});
-  crucible_points_to (crucible_field ptr "block_mask") (crucible_term {{ 0 : [32] }});
 };
 
 let fresh_aes_gcm_ctx len = do {


### PR DESCRIPTION
A [recent change](https://boringssl.googlesource.com/boringssl/+/a3aeea7c775d1859139394b57a105063351f0f5d) to BoringSSL removes the block_mask field from EVP_CIPHER_CTX. To keep this change from breaking the formal verification, we can remove all references to this field from the specs. So the spec for CipherInit won't ensure that this field has any value in particular, and other functions won't require this field to have any particular value. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

