### PR TITLE
Parameterized GCM proof

### DIFF
--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -48,6 +48,9 @@ let aesni_gcm_cipher_len = eval_size {| evp_cipher_update_len - (min gcm_len_dif
 let evp_cipher_update_bulk_encrypt = eval_size {| max 288 (aesni_gcm_cipher_len / 96 * 96) |};
 let bulk_encrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_encrypt |};
 // Separate AES-CTR32 and GHASH encryption on the remaining whole blocks
+// When there are no blocks left after the bulk operation, prove the CTR32 and GHASH
+// operations correct for 1 block. The code is not entered, so this proof is never used,
+// but it avoids complications related to proving these operations correct on 0 blocks.
 let length_after_bulk_encrypt = eval_size {| aesni_gcm_cipher_len - bulk_encrypt_used * evp_cipher_update_bulk_encrypt |};
 let whole_blocks_after_bulk_encrypt = eval_size {| max 1 (length_after_bulk_encrypt / 16) |};
 let GHASH_length_blocks_encrypt = eval_size {| whole_blocks_after_bulk_encrypt * 16|};
@@ -56,6 +59,7 @@ let GHASH_length_blocks_encrypt = eval_size {| whole_blocks_after_bulk_encrypt *
 let evp_cipher_update_bulk_decrypt = eval_size {| max 96 (aesni_gcm_cipher_len / 96 * 96) |};
 let bulk_decrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_decrypt |};
 // Separate AES-CTR32 and GHASH decryption on the remaining whole blocks
+// Limit to minimum of 1 block like in encrypt case.
 let length_after_bulk_decrypt = eval_size {| aesni_gcm_cipher_len - bulk_decrypt_used * evp_cipher_update_bulk_decrypt |};
 let whole_blocks_after_bulk_decrypt = eval_size {| max 1 (length_after_bulk_decrypt / 16) |};
 let GHASH_length_blocks_decrypt = eval_size {| whole_blocks_after_bulk_decrypt * 16|};
@@ -106,36 +110,29 @@ the original stack pointer in r11 and then calls helper routines, preventing
 the binary analysis from inferring that the return address is still on the stack
 when the routine returns. The called helper routines do not modify r11.
 */
+
+let aes_hw_ctr32_tactic = do {
+  simplify (cryptol_ss ());
+  simplify (addsimps slice_384_thms basic_ss);
+  simplify (addsimps [cmp_sub_thm] empty_ss);
+  goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
+  simplify (addsimps add_xor_slice_thms basic_ss);
+  simplify (addsimps aesenclast_thms basic_ss);
+  w4_unint_yices ["AESRound", "AESFinalRound"];
+};
+
 add_x86_preserved_reg "r11";
 aes_hw_ctr32_encrypt_blocks_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []
   true
   (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_encrypt)
-  (do {
-    simplify (cryptol_ss ());
-    simplify (addsimps slice_384_thms basic_ss);
-    simplify (addsimps [cmp_sub_thm] empty_ss);
-    goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
-    simplify (addsimps add_xor_slice_thms basic_ss);
-    simplify (addsimps aesenclast_thms basic_ss);
-    w4_unint_yices ["AESRound", "AESFinalRound"];
-  });
-default_x86_preserved_reg;
+  aes_hw_ctr32_tactic;
 
-add_x86_preserved_reg "r11";
 aes_hw_ctr32_encrypt_blocks_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []
   true
   (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_decrypt)
-  (do {
-    simplify (cryptol_ss ());
-    simplify (addsimps slice_384_thms basic_ss);
-    simplify (addsimps [cmp_sub_thm] empty_ss);
-    goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
-    simplify (addsimps add_xor_slice_thms basic_ss);
-    simplify (addsimps aesenclast_thms basic_ss);
-    w4_unint_yices ["AESRound", "AESFinalRound"];
-  });
+  aes_hw_ctr32_tactic;
 default_x86_preserved_reg;
 
 

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -24,7 +24,7 @@ include "../common/memory.saw";
  */
 
 let evp_cipher_update_gcm_len = 10;
-let evp_cipher_update_len = 353;
+let evp_cipher_update_len = 286;
 
 // If starting auth length is nonzero, bytes are collected and a single GCM_MUL is performed.
 // So bulk GCM auth length is the starting length rounded up to the next multiple of 16.
@@ -33,9 +33,9 @@ let gcm_len_diff = eval_size {| aesni_gcm_cipher_gcm_len - evp_cipher_update_gcm
 let aesni_gcm_cipher_len = eval_size {| evp_cipher_update_len - (min gcm_len_diff evp_cipher_update_len) |};
 // To get size for bulk processing core, round down to nearest multiple of 96 (min 288)
 let evp_cipher_update_bulk = eval_size {| max 288 (aesni_gcm_cipher_len / 96 * 96) |};
+let bulk_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk |};
 // Separate AES-CTR32 and GHASH performed on the remaining whole blocks
-// TODO: need to handle case when evp_cipher_update_len is less than 288
-let length_after_bulk = eval_size {| aesni_gcm_cipher_len - evp_cipher_update_bulk |};
+let length_after_bulk = eval_size {| aesni_gcm_cipher_len - bulk_used * evp_cipher_update_bulk |};
 let whole_blocks_after_bulk = eval_size {| length_after_bulk / 16 |};
 let GHASH_length_blocks = eval_size {| whole_blocks_after_bulk * 16|};
 let evp_cipher_final_gcm_len = eval_size {| evp_cipher_update_gcm_len + evp_cipher_update_len |};
@@ -44,7 +44,9 @@ print (str_concat "evp_cipher_update_len=" (show evp_cipher_update_len));
 print (str_concat "aesni_gcm_cipher_gcm_len=" (show aesni_gcm_cipher_gcm_len));
 print (str_concat "aesni_gcm_cipher_len=" (show aesni_gcm_cipher_len));
 print (str_concat "evp_cipher_update_bulk=" (show evp_cipher_update_bulk));
+print (str_concat "bulk_used=" (show bulk_used));
 print (str_concat "length_after_bulk=" (show length_after_bulk));
+print (str_concat "whole_blocks_after_bulk=" (show whole_blocks_after_bulk));
 print (str_concat "GHASH_length_blocks=" (show GHASH_length_blocks));
 
 /*

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -24,30 +24,49 @@ include "../common/memory.saw";
  */
 
 let evp_cipher_update_gcm_len = 10;
-let evp_cipher_update_len = 286;
+let evp_cipher_update_len = 254;
 
 // If starting auth length is nonzero, bytes are collected and a single GCM_MUL is performed.
 // So bulk GCM auth length is the starting length rounded up to the next multiple of 16.
 let aesni_gcm_cipher_gcm_len = eval_size {| (evp_cipher_update_gcm_len + 15) / 16 * 16 |};
 let gcm_len_diff = eval_size {| aesni_gcm_cipher_gcm_len - evp_cipher_update_gcm_len |};
 let aesni_gcm_cipher_len = eval_size {| evp_cipher_update_len - (min gcm_len_diff evp_cipher_update_len) |};
-// To get size for bulk processing core, round down to nearest multiple of 96 (min 288)
-let evp_cipher_update_bulk = eval_size {| max 288 (aesni_gcm_cipher_len / 96 * 96) |};
-let bulk_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk |};
-// Separate AES-CTR32 and GHASH performed on the remaining whole blocks
-let length_after_bulk = eval_size {| aesni_gcm_cipher_len - bulk_used * evp_cipher_update_bulk |};
-let whole_blocks_after_bulk = eval_size {| length_after_bulk / 16 |};
-let GHASH_length_blocks = eval_size {| whole_blocks_after_bulk * 16|};
+
+// To get size for bulk encrypt core, round down to nearest multiple of 96 (min 288)
+let evp_cipher_update_bulk_encrypt = eval_size {| max 288 (aesni_gcm_cipher_len / 96 * 96) |};
+let bulk_encrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_encrypt |};
+// Separate AES-CTR32 and GHASH encryption on the remaining whole blocks
+let length_after_bulk_encrypt = eval_size {| aesni_gcm_cipher_len - bulk_encrypt_used * evp_cipher_update_bulk_encrypt |};
+let whole_blocks_after_bulk_encrypt = eval_size {| length_after_bulk_encrypt / 16 |};
+let GHASH_length_blocks_encrypt = eval_size {| whole_blocks_after_bulk_encrypt * 16|};
+
+// Bulk decrypt core also operates on 6 blocks, but min is 6 blocks.
+let evp_cipher_update_bulk_decrypt = eval_size {| max 96 (aesni_gcm_cipher_len / 96 * 96) |};
+let bulk_decrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_decrypt |};
+// Separate AES-CTR32 and GHASH decryption on the remaining whole blocks
+let length_after_bulk_decrypt = eval_size {| aesni_gcm_cipher_len - bulk_decrypt_used * evp_cipher_update_bulk_decrypt |};
+let whole_blocks_after_bulk_decrypt = eval_size {| length_after_bulk_decrypt / 16 |};
+let GHASH_length_blocks_decrypt = eval_size {| whole_blocks_after_bulk_decrypt * 16|};
+
+
 let evp_cipher_final_gcm_len = eval_size {| evp_cipher_update_gcm_len + evp_cipher_update_len |};
 
 print (str_concat "evp_cipher_update_len=" (show evp_cipher_update_len));
 print (str_concat "aesni_gcm_cipher_gcm_len=" (show aesni_gcm_cipher_gcm_len));
 print (str_concat "aesni_gcm_cipher_len=" (show aesni_gcm_cipher_len));
-print (str_concat "evp_cipher_update_bulk=" (show evp_cipher_update_bulk));
-print (str_concat "bulk_used=" (show bulk_used));
-print (str_concat "length_after_bulk=" (show length_after_bulk));
-print (str_concat "whole_blocks_after_bulk=" (show whole_blocks_after_bulk));
-print (str_concat "GHASH_length_blocks=" (show GHASH_length_blocks));
+
+print (str_concat "evp_cipher_update_bulk_encrypt=" (show evp_cipher_update_bulk_encrypt));
+print (str_concat "bulk_encrypt_used=" (show bulk_encrypt_used));
+print (str_concat "length_after_bulk_encrypt=" (show length_after_bulk_encrypt));
+print (str_concat "whole_blocks_after_bulk_encrypt=" (show whole_blocks_after_bulk_encrypt));
+print (str_concat "GHASH_length_blocks_encrypt=" (show GHASH_length_blocks_encrypt));
+
+print (str_concat "evp_cipher_update_bulk_decrypt=" (show evp_cipher_update_bulk_decrypt));
+print (str_concat "bulk_decrypt_used=" (show bulk_decrypt_used));
+print (str_concat "length_after_bulk_decrypt=" (show length_after_bulk_decrypt));
+print (str_concat "whole_blocks_after_bulk_decrypt=" (show whole_blocks_after_bulk_decrypt));
+print (str_concat "GHASH_length_blocks_decrypt=" (show GHASH_length_blocks_decrypt));
+
 
 /*
 let evp_cipher_update_gcm_len = 10;
@@ -80,6 +99,47 @@ let {{ ia32cap = [0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff] : [4][32] }};
 include "AES.saw";
 include "GHASH.saw";
 include "AESNI-GCM.saw";
+
+/*
+When verifying aes_hw_ctr32_encrypt_blocks, the binary analysis must locally
+treat r11 as callee-preserved. This is necessary because this routine saves
+the original stack pointer in r11 and then calls helper routines, preventing
+the binary analysis from inferring that the return address is still on the stack
+when the routine returns. The called helper routines do not modify r11.
+*/
+print (str_concat "ctr32_blocks_encrypt=" (show whole_blocks_after_bulk_encrypt));
+add_x86_preserved_reg "r11";
+aes_hw_ctr32_encrypt_blocks_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
+  []
+  true
+  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_encrypt)
+  (do {
+    simplify (cryptol_ss ());
+    simplify (addsimps slice_384_thms basic_ss);
+    simplify (addsimps [cmp_sub_thm] empty_ss);
+    goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
+    simplify (addsimps add_xor_slice_thms basic_ss);
+    simplify (addsimps aesenclast_thms basic_ss);
+    w4_unint_yices ["AESRound", "AESFinalRound"];
+  });
+default_x86_preserved_reg;
+
+print (str_concat "ctr32_blocks_decrypt=" (show whole_blocks_after_bulk_decrypt));
+add_x86_preserved_reg "r11";
+aes_hw_ctr32_encrypt_blocks_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
+  []
+  true
+  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_decrypt)
+  (do {
+    simplify (cryptol_ss ());
+    simplify (addsimps slice_384_thms basic_ss);
+    simplify (addsimps [cmp_sub_thm] empty_ss);
+    goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
+    simplify (addsimps add_xor_slice_thms basic_ss);
+    simplify (addsimps aesenclast_thms basic_ss);
+    w4_unint_yices ["AESRound", "AESFinalRound"];
+  });
+default_x86_preserved_reg;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -204,10 +264,12 @@ let evp_cipher_ovs =
   , aes_hw_set_encrypt_key_ov
   , aes_hw_encrypt_ov
   , aes_hw_encrypt_in_place_ov
-  , aes_hw_ctr32_encrypt_blocks_ov
+  , aes_hw_ctr32_encrypt_blocks_encrypt_ov
+  , aes_hw_ctr32_encrypt_blocks_decrypt_ov
   , gcm_init_avx_ov
   , gcm_gmult_avx_ov
-  , gcm_ghash_avx_ov
+  , gcm_ghash_avx_encrypt_ov
+  , gcm_ghash_avx_decrypt_ov
   , aesni_gcm_encrypt_ov
   , aesni_gcm_decrypt_ov
   ];

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -22,6 +22,32 @@ include "../common/memory.saw";
 /*
  * Verification parameters.
  */
+
+let evp_cipher_update_gcm_len = 10;
+let evp_cipher_update_len = 353;
+
+// If starting auth length is nonzero, bytes are collected and a single GCM_MUL is performed.
+// So bulk GCM auth length is the starting length rounded up to the next multiple of 16.
+let aesni_gcm_cipher_gcm_len = eval_size {| (evp_cipher_update_gcm_len + 15) / 16 * 16 |};
+let gcm_len_diff = eval_size {| aesni_gcm_cipher_gcm_len - evp_cipher_update_gcm_len |};
+let aesni_gcm_cipher_len = eval_size {| evp_cipher_update_len - (min gcm_len_diff evp_cipher_update_len) |};
+// To get size for bulk processing core, round down to nearest multiple of 96 (min 288)
+let evp_cipher_update_bulk = eval_size {| max 288 (aesni_gcm_cipher_len / 96 * 96) |};
+// Separate AES-CTR32 and GHASH performed on the remaining whole blocks
+// TODO: need to handle case when evp_cipher_update_len is less than 288
+let length_after_bulk = eval_size {| aesni_gcm_cipher_len - evp_cipher_update_bulk |};
+let whole_blocks_after_bulk = eval_size {| length_after_bulk / 16 |};
+let GHASH_length_blocks = eval_size {| whole_blocks_after_bulk * 16|};
+let evp_cipher_final_gcm_len = eval_size {| evp_cipher_update_gcm_len + evp_cipher_update_len |};
+
+print (str_concat "evp_cipher_update_len=" (show evp_cipher_update_len));
+print (str_concat "aesni_gcm_cipher_gcm_len=" (show aesni_gcm_cipher_gcm_len));
+print (str_concat "aesni_gcm_cipher_len=" (show aesni_gcm_cipher_len));
+print (str_concat "evp_cipher_update_bulk=" (show evp_cipher_update_bulk));
+print (str_concat "length_after_bulk=" (show length_after_bulk));
+print (str_concat "GHASH_length_blocks=" (show GHASH_length_blocks));
+
+/*
 let evp_cipher_update_gcm_len = 10;
 let evp_cipher_update_bulk = 288; // multiple of 96, minimum 288
 let evp_cipher_update_len_blocks = 16; // multiple of 16
@@ -31,6 +57,7 @@ let evp_cipher_update_len = eval_size {| (16 - evp_cipher_update_gcm_len % 16) %
 let aesni_gcm_cipher_gcm_len = eval_size {| ((evp_cipher_update_gcm_len + 15) / 16) * 16 |};
 let aesni_gcm_cipher_len = eval_size {| evp_cipher_update_bulk + evp_cipher_update_len_blocks + evp_cipher_update_mres |};
 let evp_cipher_final_gcm_len = eval_size {| evp_cipher_update_gcm_len + evp_cipher_update_len |};
+*/
 
 
 include "goal-rewrites.saw";

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -24,7 +24,7 @@ include "../common/memory.saw";
  */
 
 let evp_cipher_update_gcm_len = 10;
-let evp_cipher_update_len = 254;
+let evp_cipher_update_len = 380;
 
 // If starting auth length is nonzero, bytes are collected and a single GCM_MUL is performed.
 // So bulk GCM auth length is the starting length rounded up to the next multiple of 16.
@@ -37,7 +37,7 @@ let evp_cipher_update_bulk_encrypt = eval_size {| max 288 (aesni_gcm_cipher_len 
 let bulk_encrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_encrypt |};
 // Separate AES-CTR32 and GHASH encryption on the remaining whole blocks
 let length_after_bulk_encrypt = eval_size {| aesni_gcm_cipher_len - bulk_encrypt_used * evp_cipher_update_bulk_encrypt |};
-let whole_blocks_after_bulk_encrypt = eval_size {| length_after_bulk_encrypt / 16 |};
+let whole_blocks_after_bulk_encrypt = eval_size {| max 1 (length_after_bulk_encrypt / 16) |};
 let GHASH_length_blocks_encrypt = eval_size {| whole_blocks_after_bulk_encrypt * 16|};
 
 // Bulk decrypt core also operates on 6 blocks, but min is 6 blocks.
@@ -45,7 +45,7 @@ let evp_cipher_update_bulk_decrypt = eval_size {| max 96 (aesni_gcm_cipher_len /
 let bulk_decrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_decrypt |};
 // Separate AES-CTR32 and GHASH decryption on the remaining whole blocks
 let length_after_bulk_decrypt = eval_size {| aesni_gcm_cipher_len - bulk_decrypt_used * evp_cipher_update_bulk_decrypt |};
-let whole_blocks_after_bulk_decrypt = eval_size {| length_after_bulk_decrypt / 16 |};
+let whole_blocks_after_bulk_decrypt = eval_size {| max 1 (length_after_bulk_decrypt / 16) |};
 let GHASH_length_blocks_decrypt = eval_size {| whole_blocks_after_bulk_decrypt * 16|};
 
 

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -24,7 +24,7 @@ include "../common/memory.saw";
  */
 
 let evp_cipher_update_gcm_len = 10;
-let evp_cipher_update_len = 105;
+let evp_cipher_update_len = 380;
 
 // If starting auth length is nonzero, bytes are collected and a single GCM_MUL is performed.
 // So bulk GCM auth length is the starting length rounded up to the next multiple of 16.

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -23,8 +23,20 @@ include "../common/memory.saw";
  * Verification parameters.
  */
 
-let evp_cipher_update_gcm_len = 10;
+// The number of bytes of input given to the update function.
 let evp_cipher_update_len = 380;
+// The total input length before the call to the update function.
+let evp_cipher_update_gcm_len = 10;
+
+/* 
+ * The GCM implementation has multiple phases:
+ * 1) A "bulk" encryption/decryption that operates on multiples of 6 blocks, and computes
+ *    AES/CTR32 and GHASH in parallel using different functional units of the CPU. 
+ * 2) An optimized AES/CTR32 implementation that processes the remaining blocks.
+ * 3) An optimized GHASH implementation that processes the remaining blocks. 
+ *
+ * The code below calculates the correct input lengths for each subroutine.
+ */
 
 // If starting auth length is nonzero, bytes are collected and a single GCM_MUL is performed.
 // So bulk GCM auth length is the starting length rounded up to the next multiple of 16.
@@ -32,7 +44,7 @@ let aesni_gcm_cipher_gcm_len = eval_size {| (evp_cipher_update_gcm_len + 15) / 1
 let gcm_len_diff = eval_size {| aesni_gcm_cipher_gcm_len - evp_cipher_update_gcm_len |};
 let aesni_gcm_cipher_len = eval_size {| evp_cipher_update_len - (min gcm_len_diff evp_cipher_update_len) |};
 
-// To get size for bulk encrypt core, round down to nearest multiple of 96 (min 288)
+// To get size for bulk encrypt operatin, round down to nearest multiple of 96 (min 288)
 let evp_cipher_update_bulk_encrypt = eval_size {| max 288 (aesni_gcm_cipher_len / 96 * 96) |};
 let bulk_encrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_encrypt |};
 // Separate AES-CTR32 and GHASH encryption on the remaining whole blocks
@@ -40,7 +52,7 @@ let length_after_bulk_encrypt = eval_size {| aesni_gcm_cipher_len - bulk_encrypt
 let whole_blocks_after_bulk_encrypt = eval_size {| max 1 (length_after_bulk_encrypt / 16) |};
 let GHASH_length_blocks_encrypt = eval_size {| whole_blocks_after_bulk_encrypt * 16|};
 
-// Bulk decrypt core also operates on 6 blocks, but min is 6 blocks.
+// Bulk decrypt core also operates on 6 blocks, but the minimum is 6 blocks.
 let evp_cipher_update_bulk_decrypt = eval_size {| max 96 (aesni_gcm_cipher_len / 96 * 96) |};
 let bulk_decrypt_used = eval_size {| aesni_gcm_cipher_len / evp_cipher_update_bulk_decrypt |};
 // Separate AES-CTR32 and GHASH decryption on the remaining whole blocks
@@ -48,9 +60,9 @@ let length_after_bulk_decrypt = eval_size {| aesni_gcm_cipher_len - bulk_decrypt
 let whole_blocks_after_bulk_decrypt = eval_size {| max 1 (length_after_bulk_decrypt / 16) |};
 let GHASH_length_blocks_decrypt = eval_size {| whole_blocks_after_bulk_decrypt * 16|};
 
-
 let evp_cipher_final_gcm_len = eval_size {| evp_cipher_update_gcm_len + evp_cipher_update_len |};
 
+// Log the calculated values to help find errors when the proof fails.
 print (str_concat "evp_cipher_update_len=" (show evp_cipher_update_len));
 print (str_concat "aesni_gcm_cipher_gcm_len=" (show aesni_gcm_cipher_gcm_len));
 print (str_concat "aesni_gcm_cipher_len=" (show aesni_gcm_cipher_len));
@@ -66,19 +78,6 @@ print (str_concat "bulk_decrypt_used=" (show bulk_decrypt_used));
 print (str_concat "length_after_bulk_decrypt=" (show length_after_bulk_decrypt));
 print (str_concat "whole_blocks_after_bulk_decrypt=" (show whole_blocks_after_bulk_decrypt));
 print (str_concat "GHASH_length_blocks_decrypt=" (show GHASH_length_blocks_decrypt));
-
-
-/*
-let evp_cipher_update_gcm_len = 10;
-let evp_cipher_update_bulk = 288; // multiple of 96, minimum 288
-let evp_cipher_update_len_blocks = 80; // multiple of 16
-let evp_cipher_update_mres = 10; // reduced mod 16
-
-let evp_cipher_update_len = eval_size {| (16 - evp_cipher_update_gcm_len % 16) % 16 + evp_cipher_update_bulk + evp_cipher_update_len_blocks + evp_cipher_update_mres |};
-let aesni_gcm_cipher_gcm_len = eval_size {| ((evp_cipher_update_gcm_len + 15) / 16) * 16 |};
-let aesni_gcm_cipher_len = eval_size {| evp_cipher_update_bulk + evp_cipher_update_len_blocks + evp_cipher_update_mres |};
-let evp_cipher_final_gcm_len = eval_size {| evp_cipher_update_gcm_len + evp_cipher_update_len |};
-*/
 
 
 include "goal-rewrites.saw";
@@ -107,7 +106,6 @@ the original stack pointer in r11 and then calls helper routines, preventing
 the binary analysis from inferring that the return address is still on the stack
 when the routine returns. The called helper routines do not modify r11.
 */
-print (str_concat "ctr32_blocks_encrypt=" (show whole_blocks_after_bulk_encrypt));
 add_x86_preserved_reg "r11";
 aes_hw_ctr32_encrypt_blocks_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []
@@ -124,7 +122,6 @@ aes_hw_ctr32_encrypt_blocks_encrypt_ov <- llvm_verify_x86 m "../../build/x86/cry
   });
 default_x86_preserved_reg;
 
-print (str_concat "ctr32_blocks_decrypt=" (show whole_blocks_after_bulk_decrypt));
 add_x86_preserved_reg "r11";
 aes_hw_ctr32_encrypt_blocks_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -24,7 +24,7 @@ include "../common/memory.saw";
  */
 
 let evp_cipher_update_gcm_len = 10;
-let evp_cipher_update_len = 380;
+let evp_cipher_update_len = 105;
 
 // If starting auth length is nonzero, bytes are collected and a single GCM_MUL is performed.
 // So bulk GCM auth length is the starting length rounded up to the next multiple of 16.

--- a/SAW/proof/AES/AES.saw
+++ b/SAW/proof/AES/AES.saw
@@ -183,20 +183,12 @@ the original stack pointer in r11 and then calls helper routines, preventing
 the binary analysis from inferring that the return address is still on the stack
 when the routine returns. The called helper routines do not modify r11.
 */
+print (str_concat "ctr32_blocks=" (show whole_blocks_after_bulk));
 add_x86_preserved_reg "r11";
-llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
-  []
-  true
-  (aes_hw_ctr32_encrypt_blocks_spec 2)
-  (do {
-    simplify (cryptol_ss ());
-    simplify (addsimps slice_384_thms basic_ss);
-    w4_unint_yices ["AESRound", "AESFinalRound"];
-  });
 aes_hw_ctr32_encrypt_blocks_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
   []
   true
-  (aes_hw_ctr32_encrypt_blocks_spec 1)
+  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk)
   (do {
     simplify (cryptol_ss ());
     simplify (addsimps slice_384_thms basic_ss);

--- a/SAW/proof/AES/AES.saw
+++ b/SAW/proof/AES/AES.saw
@@ -176,26 +176,3 @@ aes_hw_decrypt_in_place_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_t
     w4_unint_yices ["AESInvRound", "AESFinalInvRound"];
   });
 
-/*
-When verifying aes_hw_ctr32_encrypt_blocks, the binary analysis must locally
-treat r11 as callee-preserved. This is necessary because this routine saves
-the original stack pointer in r11 and then calls helper routines, preventing
-the binary analysis from inferring that the return address is still on the stack
-when the routine returns. The called helper routines do not modify r11.
-*/
-print (str_concat "ctr32_blocks=" (show whole_blocks_after_bulk));
-add_x86_preserved_reg "r11";
-aes_hw_ctr32_encrypt_blocks_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
-  []
-  true
-  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk)
-  (do {
-    simplify (cryptol_ss ());
-    simplify (addsimps slice_384_thms basic_ss);
-    simplify (addsimps [cmp_sub_thm] empty_ss);
-    goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
-    simplify (addsimps add_xor_slice_thms basic_ss);
-    simplify (addsimps aesenclast_thms basic_ss);
-    w4_unint_yices ["AESRound", "AESFinalRound"];
-  });
-default_x86_preserved_reg;

--- a/SAW/proof/AES/AESNI-GCM.saw
+++ b/SAW/proof/AES/AESNI-GCM.saw
@@ -28,17 +28,21 @@ let aesni_gcm_cipher_spec enc gcm_len len = do {
 
   crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `len : [64] }}), key_ptr, ivec_ptr, Xi_ptr];
 
-  let res_len = eval_size {| len - (len % (6 * AES_BLOCK_SIZE)) |};
+  let bulk_len = eval_size {| max (3 * 6 * AES_BLOCK_SIZE) ((len / (6 * AES_BLOCK_SIZE)) * (6 * AES_BLOCK_SIZE)) |};
+  let do_bulk = eval_size {| len / bulk_len |};
+  let res_len = eval_size {| do_bulk * bulk_len |};
   let res_ctr = eval_size {| ctr + res_len / AES_BLOCK_SIZE |};
 
-  crucible_points_to_untyped out_ptr (crucible_term {{ ctr32_encrypt ctx (take`{res_len} in_) }});
-
   crucible_points_to ivec_ptr (crucible_term {{ ivec # (split (`res_ctr : [32])) }});
-
   crucible_points_to_untyped (crucible_elem Xi_ptr 2) (crucible_term {{ get_Htable ctx }});
   crucible_points_to_untyped (crucible_elem Xi_ptr 1) (crucible_term {{ get_H ctx }});
 
-  crucible_points_to_untyped (crucible_elem Xi_ptr 0) (crucible_term {{ (cipher_update enc ctx (take`{res_len} in_)).Xi }} );
+  if eval_bool {{ `do_bulk == 0 }} then do {
+    crucible_points_to_untyped (crucible_elem Xi_ptr 0) (crucible_term Xi);
+  } else do {
+    crucible_points_to_untyped out_ptr (crucible_term {{ ctr32_encrypt ctx (take`{res_len} in_) }});
+    crucible_points_to_untyped (crucible_elem Xi_ptr 0) (crucible_term {{ (cipher_update enc ctx (take`{res_len} in_)).Xi }} );
+  };
 
   crucible_return (crucible_term {{ `res_len : [64] }});
 };

--- a/SAW/proof/AES/AESNI-GCM.saw
+++ b/SAW/proof/AES/AESNI-GCM.saw
@@ -9,6 +9,9 @@
 
 let aesni_gcm_cipher_spec enc gcm_len len = do {
   let ctr = eval_size {| gcm_len / AES_BLOCK_SIZE + 2 |};
+  let encT = eval_int {{ enc }};
+  // Bulk encrypt requires 3*6 blocks of input. Bulk decrypt only requires 6 blocks.
+  let min_size = eval_size {| (1 + 2 * encT) * 6 * AES_BLOCK_SIZE |};
 
   (in_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array len (llvm_int 8));
   out_ptr <- crucible_alloc (llvm_array len (llvm_int 8));
@@ -28,7 +31,7 @@ let aesni_gcm_cipher_spec enc gcm_len len = do {
 
   crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `len : [64] }}), key_ptr, ivec_ptr, Xi_ptr];
 
-  let bulk_len = eval_size {| max (3 * 6 * AES_BLOCK_SIZE) ((len / (6 * AES_BLOCK_SIZE)) * (6 * AES_BLOCK_SIZE)) |};
+  let bulk_len = eval_size {| max min_size ((len / (6 * AES_BLOCK_SIZE)) * (6 * AES_BLOCK_SIZE)) |};
   let do_bulk = eval_size {| len / bulk_len |};
   let res_len = eval_size {| do_bulk * bulk_len |};
   let res_ctr = eval_size {| ctr + res_len / AES_BLOCK_SIZE |};

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -67,7 +67,7 @@ gcm_gmult_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_
   rme;
 
 enable_what4_hash_consing;
-print (str_concat "GHASH_length_blocks_encrypt=" (show GHASH_length_blocks_encrypt));
+
 gcm_ghash_avx_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
   [ ("gcm_ghash_avx", 1800)
   ]
@@ -85,9 +85,7 @@ gcm_ghash_avx_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_tes
     simplify (addsimps concat_assoc_2_thms empty_ss);
     w4_unint_z3 ["pmult", "gcm_polyval"];
   });
-disable_what4_hash_consing;
 
-print (str_concat "GHASH_length_blocks_decrypt=" (show GHASH_length_blocks_decrypt));
 gcm_ghash_avx_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
   [ ("gcm_ghash_avx", 1800)
   ]
@@ -105,5 +103,6 @@ gcm_ghash_avx_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_tes
     simplify (addsimps concat_assoc_2_thms empty_ss);
     w4_unint_z3 ["pmult", "gcm_polyval"];
   });
+  
 disable_what4_hash_consing;
 

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -75,7 +75,8 @@ gcm_ghash_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_
   (gcm_ghash_avx_spec GHASH_length_blocks)
   (do {
     simplify (cryptol_ss ());
-    simplify (addsimp gcm_ghash_avx_thm empty_ss);
+    simplify (addsimp gcm_ghash_avx_thm_8 empty_ss);
+    simplify (addsimp gcm_ghash_avx_thm_rem empty_ss);
     simplify (addsimps xor_slice_append_thms basic_ss);
     simplify (addsimps slice_slice_thms empty_ss);
     simplify (addsimps xor_slice_append_thms basic_ss);

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -75,8 +75,7 @@ gcm_ghash_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_
   (gcm_ghash_avx_spec GHASH_length_blocks)
   (do {
     simplify (cryptol_ss ());
-    simplify (addsimp gcm_ghash_avx_thm_8 empty_ss);
-    simplify (addsimp gcm_ghash_avx_thm_rem empty_ss);
+    simplify (addsimps gcm_ghash_avx_thms empty_ss);
     simplify (addsimps xor_slice_append_thms basic_ss);
     simplify (addsimps slice_slice_thms empty_ss);
     simplify (addsimps xor_slice_append_thms basic_ss);

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -67,15 +67,35 @@ gcm_gmult_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_
   rme;
 
 enable_what4_hash_consing;
-print (str_concat "GHASH_length_blocks=" (show GHASH_length_blocks));
-gcm_ghash_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
+print (str_concat "GHASH_length_blocks_encrypt=" (show GHASH_length_blocks_encrypt));
+gcm_ghash_avx_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
   [ ("gcm_ghash_avx", 1800)
   ]
   true
-  (gcm_ghash_avx_spec GHASH_length_blocks)
+  (gcm_ghash_avx_spec GHASH_length_blocks_encrypt)
   (do {
     simplify (cryptol_ss ());
-    simplify (addsimp gcm_ghash_avx_thm empty_ss);
+    simplify (addsimp gcm_ghash_avx_encrypt_thm empty_ss);
+    goal_eval_unint ["pmult", "gcm_polyval"];
+    simplify (addsimps xor_slice_append_thms basic_ss);
+    simplify (addsimps slice_slice_thms empty_ss);
+    simplify (addsimps xor_slice_append_thms basic_ss);
+    simplify (addsimps concat_assoc_0_thms empty_ss);
+    simplify (addsimps concat_assoc_1_thms empty_ss);
+    simplify (addsimps concat_assoc_2_thms empty_ss);
+    w4_unint_z3 ["pmult", "gcm_polyval"];
+  });
+disable_what4_hash_consing;
+
+print (str_concat "GHASH_length_blocks_decrypt=" (show GHASH_length_blocks_decrypt));
+gcm_ghash_avx_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
+  [ ("gcm_ghash_avx", 1800)
+  ]
+  true
+  (gcm_ghash_avx_spec GHASH_length_blocks_decrypt)
+  (do {
+    simplify (cryptol_ss ());
+    simplify (addsimp gcm_ghash_avx_decrypt_thm empty_ss);
     goal_eval_unint ["pmult", "gcm_polyval"];
     simplify (addsimps xor_slice_append_thms basic_ss);
     simplify (addsimps slice_slice_thms empty_ss);

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -70,7 +70,7 @@ enable_what4_hash_consing;
 
 let gcm_ghash_avx_tactic = do {
   simplify (cryptol_ss ());
-  simplify (addsimp gcm_ghash_avx_encrypt_thm empty_ss);
+  simplify (addsimps gcm_ghash_avx_thms empty_ss);
   goal_eval_unint ["pmult", "gcm_polyval"];
   simplify (addsimps xor_slice_append_thms basic_ss);
   simplify (addsimps slice_slice_thms empty_ss);

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -67,11 +67,12 @@ gcm_gmult_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_
   rme;
 
 enable_what4_hash_consing;
+print (str_concat "GHASH_length_blocks=" (show GHASH_length_blocks));
 gcm_ghash_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
   [ ("gcm_ghash_avx", 1800)
   ]
   true
-  (gcm_ghash_avx_spec evp_cipher_update_len_blocks)
+  (gcm_ghash_avx_spec GHASH_length_blocks)
   (do {
     unfolding ["gcm_ghash", "gcm_ghash_block", "gcm_polyval"];
     simplify (addsimps [ghash_mul_thm, ghash_red_thm] empty_ss);

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -68,41 +68,32 @@ gcm_gmult_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_
 
 enable_what4_hash_consing;
 
+let gcm_ghash_avx_tactic = do {
+  simplify (cryptol_ss ());
+  simplify (addsimp gcm_ghash_avx_encrypt_thm empty_ss);
+  goal_eval_unint ["pmult", "gcm_polyval"];
+  simplify (addsimps xor_slice_append_thms basic_ss);
+  simplify (addsimps slice_slice_thms empty_ss);
+  simplify (addsimps xor_slice_append_thms basic_ss);
+  simplify (addsimps concat_assoc_0_thms empty_ss);
+  simplify (addsimps concat_assoc_1_thms empty_ss);
+  simplify (addsimps concat_assoc_2_thms empty_ss);
+  w4_unint_z3 ["pmult", "gcm_polyval"];
+};
+
 gcm_ghash_avx_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
   [ ("gcm_ghash_avx", 1800)
   ]
   true
   (gcm_ghash_avx_spec GHASH_length_blocks_encrypt)
-  (do {
-    simplify (cryptol_ss ());
-    simplify (addsimp gcm_ghash_avx_encrypt_thm empty_ss);
-    goal_eval_unint ["pmult", "gcm_polyval"];
-    simplify (addsimps xor_slice_append_thms basic_ss);
-    simplify (addsimps slice_slice_thms empty_ss);
-    simplify (addsimps xor_slice_append_thms basic_ss);
-    simplify (addsimps concat_assoc_0_thms empty_ss);
-    simplify (addsimps concat_assoc_1_thms empty_ss);
-    simplify (addsimps concat_assoc_2_thms empty_ss);
-    w4_unint_z3 ["pmult", "gcm_polyval"];
-  });
+  gcm_ghash_avx_tactic;
 
 gcm_ghash_avx_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
   [ ("gcm_ghash_avx", 1800)
   ]
   true
   (gcm_ghash_avx_spec GHASH_length_blocks_decrypt)
-  (do {
-    simplify (cryptol_ss ());
-    simplify (addsimp gcm_ghash_avx_decrypt_thm empty_ss);
-    goal_eval_unint ["pmult", "gcm_polyval"];
-    simplify (addsimps xor_slice_append_thms basic_ss);
-    simplify (addsimps slice_slice_thms empty_ss);
-    simplify (addsimps xor_slice_append_thms basic_ss);
-    simplify (addsimps concat_assoc_0_thms empty_ss);
-    simplify (addsimps concat_assoc_1_thms empty_ss);
-    simplify (addsimps concat_assoc_2_thms empty_ss);
-    w4_unint_z3 ["pmult", "gcm_polyval"];
-  });
-  
+  gcm_ghash_avx_tactic;
+
 disable_what4_hash_consing;
 

--- a/SAW/proof/AES/goal-rewrites.saw
+++ b/SAW/proof/AES/goal-rewrites.saw
@@ -237,6 +237,7 @@ let prove_gcm_ghash_avx_thm len = prove_print
   })
   (rewrite (cryptol_ss ()) {{ \H Xi (in : [len][8]) -> gcm_ghash H Xi in == gcm_ghash_avx`{n=((len/16)-1)/8} H Xi in }});
 
+/*
 let GHASH_bulk_len = eval_size {| 8 * 16 |};
 gcm_ghash_avx_thm_bulk <- prove_gcm_ghash_avx_thm GHASH_bulk_len;
 let GHASH_length_remainder = eval_size {| GHASH_length_blocks % GHASH_bulk_len |};
@@ -245,6 +246,10 @@ let gcm_ghash_avx_thms =
   [ gcm_ghash_avx_thm_bulk
   , gcm_ghash_avx_thm_rem
   ];
+*/
+
+gcm_ghash_avx_encrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_encrypt;
+gcm_ghash_avx_decrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_decrypt;
 
 let prove_ctr32_encrypt_thm gcm_len len = prove_print
   (do {
@@ -252,13 +257,18 @@ let prove_ctr32_encrypt_thm gcm_len len = prove_print
   })
   (rewrite (cryptol_ss ()) {{ \key iv Xi (in : [len][8]) -> ctr32_encrypt ({ key = key, iv = iv, Xi = Xi, len = `gcm_len } : AES_GCM_Ctx) in == join (map split (aesni_gcm_ctr32_encrypt_block ({ key = key, iv = iv, Xi = Xi, len = `gcm_len } : AES_GCM_Ctx) in)) }});
 
-ctr32_encrypt_thm <- prove_ctr32_encrypt_thm aesni_gcm_cipher_gcm_len evp_cipher_update_bulk;
+ctr32_encrypt_encrypt_thm <- prove_ctr32_encrypt_thm aesni_gcm_cipher_gcm_len evp_cipher_update_bulk_encrypt;
+ctr32_encrypt_decrypt_thm <- prove_ctr32_encrypt_thm aesni_gcm_cipher_gcm_len evp_cipher_update_bulk_decrypt;
+let ctr32_encrypt_thms =
+  [ ctr32_encrypt_encrypt_thm
+  , ctr32_encrypt_decrypt_thm
+  ];
 
 let prove_cipher_update_avx_thm enc gcm_len len = prove_print
   (do {
     unfolding ["cipher_update", "cipher_update_byte"];
     simplify (cryptol_ss ());
-    simplify (addsimp ctr32_encrypt_thm empty_ss);
+    simplify (addsimps ctr32_encrypt_thms empty_ss);
     simplify (addsimp gcm_pmult_pmod_thm empty_ss);
     goal_eval_unint ["pmult", "pmod", "gcm_polyval", "gcm_polyval_mul", "gcm_polyval_mul_pmult3", "gcm_polyval_mul_pmult4", "gcm_polyval_red", "gcm_polyval_red_pmult", "aes_hw_encrypt", "aesni_gcm_ctr32_encrypt_block"];
     simplify (addsimps gcm_polyval_thms empty_ss);
@@ -267,8 +277,9 @@ let prove_cipher_update_avx_thm enc gcm_len len = prove_print
   })
   (rewrite (cryptol_ss ()) {{ \key iv Xi (in : [len][8]) -> (cipher_update enc ({ key = key, iv = iv, Xi = Xi, len = `gcm_len } : AES_GCM_Ctx) in).Xi == aesni_gcm_cipher enc ({ key = key, iv = iv, Xi = Xi, len = `gcm_len } : AES_GCM_Ctx) in }});
 
-encrypt_update_avx_thm <- prove_cipher_update_avx_thm {{ 1 : [32] }} aesni_gcm_cipher_gcm_len evp_cipher_update_bulk;
-decrypt_update_avx_thm <- prove_cipher_update_avx_thm {{ 0 : [32] }} aesni_gcm_cipher_gcm_len evp_cipher_update_bulk;
+
+encrypt_update_avx_thm <- prove_cipher_update_avx_thm {{ 1 : [32] }} aesni_gcm_cipher_gcm_len evp_cipher_update_bulk_encrypt;
+decrypt_update_avx_thm <- prove_cipher_update_avx_thm {{ 0 : [32] }} aesni_gcm_cipher_gcm_len evp_cipher_update_bulk_decrypt;
 let cipher_update_avx_thms =
   [ encrypt_update_avx_thm
   , decrypt_update_avx_thm
@@ -304,7 +315,7 @@ let aesni_gcm_cipher_tactic = do {
   simplify (addsimps [aesenc_aesenclast_thm] empty_ss);
   simplify (cryptol_ss ());
   simplify (addsimps cipher_update_avx_thms empty_ss);
-  simplify (addsimp ctr32_encrypt_thm empty_ss);
+  simplify (addsimps ctr32_encrypt_thms empty_ss);
   goal_eval_unint ["pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule"];
   simplify (addsimps xor_slice_append_thms basic_ss);
   simplify (addsimps slice_slice_thms empty_ss);

--- a/SAW/proof/AES/goal-rewrites.saw
+++ b/SAW/proof/AES/goal-rewrites.saw
@@ -241,6 +241,10 @@ let GHASH_bulk_len = eval_size {| 8 * 16 |};
 gcm_ghash_avx_thm_bulk <- prove_gcm_ghash_avx_thm GHASH_bulk_len;
 let GHASH_length_remainder = eval_size {| GHASH_length_blocks % GHASH_bulk_len |};
 gcm_ghash_avx_thm_rem <- prove_gcm_ghash_avx_thm GHASH_length_remainder;
+let gcm_ghash_avx_thms =
+  [ gcm_ghash_avx_thm_bulk
+  , gcm_ghash_avx_thm_rem
+  ];
 
 let prove_ctr32_encrypt_thm gcm_len len = prove_print
   (do {

--- a/SAW/proof/AES/goal-rewrites.saw
+++ b/SAW/proof/AES/goal-rewrites.saw
@@ -237,7 +237,10 @@ let prove_gcm_ghash_avx_thm len = prove_print
   })
   (rewrite (cryptol_ss ()) {{ \H Xi (in : [len][8]) -> gcm_ghash H Xi in == gcm_ghash_avx H Xi in }});
 
-gcm_ghash_avx_thm <- prove_gcm_ghash_avx_thm evp_cipher_update_len_blocks;
+let GHASH_bulk_len = eval_size {| 8 * 16 |};
+gcm_ghash_avx_thm_bulk <- prove_gcm_ghash_avx_thm GHASH_bulk_len;
+let GHASH_length_remainder = eval_size {| GHASH_length_blocks % GHASH_bulk_len |};
+gcm_ghash_avx_thm_rem <- prove_gcm_ghash_avx_thm GHASH_length_remainder;
 
 let prove_ctr32_encrypt_thm gcm_len len = prove_print
   (do {

--- a/SAW/proof/AES/goal-rewrites.saw
+++ b/SAW/proof/AES/goal-rewrites.saw
@@ -239,6 +239,10 @@ let prove_gcm_ghash_avx_thm len = prove_print
 
 gcm_ghash_avx_encrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_encrypt;
 gcm_ghash_avx_decrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_decrypt;
+let gcm_ghash_avx_thms =
+  [ gcm_ghash_avx_encrypt_thm
+  , gcm_ghash_avx_encrypt_thm
+  ];
 
 let prove_ctr32_encrypt_thm gcm_len len = prove_print
   (do {

--- a/SAW/proof/AES/goal-rewrites.saw
+++ b/SAW/proof/AES/goal-rewrites.saw
@@ -237,17 +237,6 @@ let prove_gcm_ghash_avx_thm len = prove_print
   })
   (rewrite (cryptol_ss ()) {{ \H Xi (in : [len][8]) -> gcm_ghash H Xi in == gcm_ghash_avx`{n=((len/16)-1)/8} H Xi in }});
 
-/*
-let GHASH_bulk_len = eval_size {| 8 * 16 |};
-gcm_ghash_avx_thm_bulk <- prove_gcm_ghash_avx_thm GHASH_bulk_len;
-let GHASH_length_remainder = eval_size {| GHASH_length_blocks % GHASH_bulk_len |};
-gcm_ghash_avx_thm_rem <- prove_gcm_ghash_avx_thm GHASH_length_remainder;
-let gcm_ghash_avx_thms =
-  [ gcm_ghash_avx_thm_bulk
-  , gcm_ghash_avx_thm_rem
-  ];
-*/
-
 gcm_ghash_avx_encrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_encrypt;
 gcm_ghash_avx_decrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_decrypt;
 

--- a/SAW/spec/AES/AES-GCM-implementation.cry
+++ b/SAW/spec/AES/AES-GCM-implementation.cry
@@ -66,14 +66,14 @@ gcm_polyval_avx H X = x30
 /*
  * aesni_gcm_cipher Cryptol implementation
  */
-aesni_gcm_cipher : {n} (fin n) => [32] -> AES_GCM_Ctx -> [(3 + n) * 6 * 16][8] -> [16][8]
+aesni_gcm_cipher : {n} (fin n) => [32] -> AES_GCM_Ctx -> [(1 + n) * 6 * 16][8] -> [16][8]
 aesni_gcm_cipher enc ctx in = ctx''.Xi
   where
     enc_blks = if enc ! 0
       then split (aesni_gcm_ctr32_encrypt_block ctx in)
       else split (map join (split in))
     ctx' = aesni_gcm_cipher_block6 enc False ctx (enc_blks @ 0)
-    ctx'' = foldl (aesni_gcm_cipher_block6 enc (enc ! 0)) ctx' (enc_blks @@ [1 .. (2 + n)])
+    ctx'' = foldl (aesni_gcm_cipher_block6 enc (enc ! 0)) ctx' (drop`{1} enc_blks)
 
 aesni_gcm_ctr32_encrypt_block : {n} (fin n) => AES_GCM_Ctx -> [n * 16][8] -> [n][16 * 8]
 aesni_gcm_ctr32_encrypt_block ctx in = out


### PR DESCRIPTION
This proof calculates lengths for all subroutines, and it works for input lengths up to 400 bytes or so.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

