### PR TITLE
Run AES-GCM check concurrently.

### DIFF
--- a/SAW/proof/AES/AES-GCM-check-entrypoint.go
+++ b/SAW/proof/AES/AES-GCM-check-entrypoint.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	utility "aws-lc-verification/proof/common"
+	"log"
+	"os"
+	"sync"
+)
+
+// Due to memory usage (each select_check takes 8GB memory) and limit of container size (largest one has 145GB memory).
+// |aes_gcm_process_limit| is needed here to limit the number of saw processes.
+const aes_gcm_process_limit int = 20
+
+func main() {
+	log.Printf("Started AES-GCM check.")
+	// When 'AES_GCM_SELECTCHECK' is undefined, quickcheck is executed.
+	env_var := os.Getenv("AES_GCM_SELECTCHECK")
+	if len(env_var) == 0 {
+		utility.RunSawScript("verify-AES-GCM-quickcheck.saw")
+		return
+	}
+	// When 'AES_GCM_SELECTCHECK' is defined, formal verification is executed with different `evp_cipher_update_len`.
+	// Generate saw scripts based on the verification template and evp_cipher_update_len range [1, 384].
+	var wg sync.WaitGroup
+	process_count := 0
+	for i := 1; i <= 384; i++ {
+		wg.Add(1)
+		saw_template := "verify-AES-GCM-selectcheck-template.txt"
+		placeholder_name := "TARGET_LEN_PLACEHOLDER"
+		go utility.CreateAndRunSawScript(saw_template, placeholder_name, i, &wg)
+		utility.Wait(&process_count, aes_gcm_process_limit, &wg)
+	}
+
+	wg.Wait()
+	log.Printf("Completed AES-GCM check.")
+}

--- a/SAW/proof/AES/AES-GCM-check-entrypoint.go
+++ b/SAW/proof/AES/AES-GCM-check-entrypoint.go
@@ -28,7 +28,7 @@ func main() {
 	// Generate saw scripts based on the verification template and evp_cipher_update_len range [1, 384].
 	var wg sync.WaitGroup
 	process_count := 0
-	for i := 1; i <= 384; i++ {
+	for i := 100; i <= 384; i++ {
 		wg.Add(1)
 		saw_template := "verify-AES-GCM-selectcheck-template.txt"
 		placeholder_name := "TARGET_LEN_PLACEHOLDER"

--- a/SAW/proof/AES/AES-GCM-check-entrypoint.go
+++ b/SAW/proof/AES/AES-GCM-check-entrypoint.go
@@ -28,7 +28,7 @@ func main() {
 	// Generate saw scripts based on the verification template and evp_cipher_update_len range [1, 384].
 	var wg sync.WaitGroup
 	process_count := 0
-	for i := 100; i <= 384; i++ {
+	for i := 1; i <= 384; i++ {
 		wg.Add(1)
 		saw_template := "verify-AES-GCM-selectcheck-template.txt"
 		placeholder_name := "TARGET_LEN_PLACEHOLDER"

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -23,8 +23,6 @@ include "../common/memory.saw";
  * Verification parameters.
  */
 
-// The number of bytes of input given to the update function.
-let evp_cipher_update_len = 380;
 // The total input length before the call to the update function.
 let evp_cipher_update_gcm_len = 10;
 

--- a/SAW/proof/AES/goal-rewrites.saw
+++ b/SAW/proof/AES/goal-rewrites.saw
@@ -241,7 +241,7 @@ gcm_ghash_avx_encrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_encrypt
 gcm_ghash_avx_decrypt_thm <- prove_gcm_ghash_avx_thm GHASH_length_blocks_decrypt;
 let gcm_ghash_avx_thms =
   [ gcm_ghash_avx_encrypt_thm
-  , gcm_ghash_avx_encrypt_thm
+  , gcm_ghash_avx_decrypt_thm
   ];
 
 let prove_ctr32_encrypt_thm gcm_len len = prove_print

--- a/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
+++ b/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
@@ -4,7 +4,7 @@
 */
 
 // The number of bytes of input given to the update function.
-let evp_cipher_update_len = 101;
+let evp_cipher_update_len = 380;
 
 print (str_concat "Running AES-GCM quick check with evp_cipher_update_len=" (show evp_cipher_update_len));
 

--- a/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
+++ b/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
@@ -9,3 +9,5 @@ let evp_cipher_update_len = 101;
 print (str_concat "Running AES-GCM quick check with evp_cipher_update_len=" (show evp_cipher_update_len));
 
 include "AES-GCM.saw";
+
+print (str_concat "Completed AES-GCM quick check with evp_cipher_update_len=" (show evp_cipher_update_len));

--- a/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
+++ b/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+// The number of bytes of input given to the update function.
+let evp_cipher_update_len = 380;
+
+print (str_concat "Running AES-GCM quick check with evp_cipher_update_len=" (show evp_cipher_update_len));
+
+include "AES-GCM.saw";

--- a/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
+++ b/SAW/proof/AES/verify-AES-GCM-quickcheck.saw
@@ -4,7 +4,7 @@
 */
 
 // The number of bytes of input given to the update function.
-let evp_cipher_update_len = 380;
+let evp_cipher_update_len = 101;
 
 print (str_concat "Running AES-GCM quick check with evp_cipher_update_len=" (show evp_cipher_update_len));
 

--- a/SAW/proof/AES/verify-AES-GCM-selectcheck-template.txt
+++ b/SAW/proof/AES/verify-AES-GCM-selectcheck-template.txt
@@ -1,0 +1,11 @@
+/* 
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+// The number of bytes of input given to the update function.
+let evp_cipher_update_len = TARGET_LEN_PLACEHOLDER;
+
+print (str_concat "Running AES-GCM select check with evp_cipher_update_len=" (show evp_cipher_update_len));
+
+include "AES-GCM.saw";

--- a/SAW/proof/AES/verify-AES-GCM-selectcheck-template.txt
+++ b/SAW/proof/AES/verify-AES-GCM-selectcheck-template.txt
@@ -9,3 +9,5 @@ let evp_cipher_update_len = TARGET_LEN_PLACEHOLDER;
 print (str_concat "Running AES-GCM select check with evp_cipher_update_len=" (show evp_cipher_update_len));
 
 include "AES-GCM.saw";
+
+print (str_concat "Completed AES-GCM select check with evp_cipher_update_len=" (show evp_cipher_update_len));

--- a/SAW/proof/AES/verify-AES-GCM.saw
+++ b/SAW/proof/AES/verify-AES-GCM.saw
@@ -1,7 +1,0 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
-*/
-
-include "AES-GCM.saw";
-

--- a/SAW/proof/common/utility.go
+++ b/SAW/proof/common/utility.go
@@ -41,20 +41,33 @@ func CreateAndRunSawScript(path_to_template string, placeholder_key string, valu
 	defer os.Remove(file_name)
 	// Run saw script.
 	defer wg.Done()
-	RunSawScript(file_name, path_to_template)
+	RunSelectCheckScript(file_name, path_to_template)
 }
 
 // A function to run saw script.
-func RunSawScript(path_to_saw_file string, path_to_template string) {
+func RunSelectCheckScript(path_to_saw_file string, path_to_template string) {
 	log.Printf("Running saw script %s. Related template: %s.", path_to_saw_file, path_to_template)
 	cmd := exec.Command("saw", path_to_saw_file)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	if e != nil {
-		log.Fatal("Failed to run saw script %s. Related template: %s.", path_to_saw_file, path_to_template, e)
+	if err != nil {
+		log.Fatal("Failed to run saw script %s. Related template: %s.", path_to_saw_file, path_to_template, err)
 	} else {
 		log.Printf("Finished executing saw script %s. Related template: %s.", path_to_saw_file, path_to_template)
+	}
+}
+
+func RunSawScript(path_to_saw_file string) {
+	log.Printf("Running saw script %s.", path_to_saw_file)
+	cmd := exec.Command("saw", path_to_saw_file)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		log.Fatal("Failed to run saw script %s.", path_to_saw_file, err)
+	} else {
+		log.Printf("Finished executing saw script %s.", path_to_saw_file)
 	}
 }
 

--- a/SAW/proof/common/utility.go
+++ b/SAW/proof/common/utility.go
@@ -41,17 +41,21 @@ func CreateAndRunSawScript(path_to_template string, placeholder_key string, valu
 	defer os.Remove(file_name)
 	// Run saw script.
 	defer wg.Done()
-	RunSawScript(file_name)
+	RunSawScript(file_name, path_to_template)
 }
 
 // A function to run saw script.
-func RunSawScript(path_to_saw_file string) {
-	log.Printf("Running saw script %s", path_to_saw_file)
+func RunSawScript(path_to_saw_file string, path_to_template string) {
+	log.Printf("Running saw script %s. Related template: %s.", path_to_saw_file, path_to_template)
 	cmd := exec.Command("saw", path_to_saw_file)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	CheckError(err)
+	if e != nil {
+		log.Fatal("Failed to run saw script %s. Related template: %s.", path_to_saw_file, path_to_template, e)
+	} else {
+		log.Printf("Finished executing saw script %s. Related template: %s.", path_to_saw_file, path_to_template)
+	}
 }
 
 // A function to limit number of concurrent processes.

--- a/SAW/scripts/run_checks.sh
+++ b/SAW/scripts/run_checks.sh
@@ -9,11 +9,9 @@ set -ex
 (cd proof/SHA512 && go run SHA512-384-check-entrypoint.go)
 saw proof/SHA512/verify-SHA512-512-quickcheck.saw
 (cd proof/HMAC && go run HMAC-check-entrypoint.go)
-# TODO: add select check flavors for AES-GCM and AES-KW
-saw proof/AES/verify-AES-GCM.saw
+(cd proof/AES && go run AES-GCM-check-entrypoint.go)
 saw proof/AES_KW/verify-AES_KW.saw
 saw proof/AES_KW/verify-AES_KWP.saw
 saw proof/ECDSA/verify-ECDSA.saw
 saw proof/ECDH/verify-ECDH.saw
 saw proof/RSA/verify-RSA.saw
-


### PR DESCRIPTION
This PR added new entry of AES-GCM formal verification. The new entry `SELECT_CHECK` executes AES-GCM verification with different `evp_cipher_update_len` concurrently.

Related SIM: CryptoAlg-630

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

