### PR TITLE
RSA verification issues with BN_is_odd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	url = https://github.com/samuel40791765/aws-lc.git
-	branch = boringssl-merge-7fffa4636cf7647daf981914286d5d32f1beab6d
+	branch = main
+	url = https://github.com/awslabs/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	url = https://github.com/awslabs/aws-lc.git
-	branch = boringmerge20210317
+	url = https://github.com/samuel40791765/aws-lc.git
+	branch = boringssl-merge-7fffa4636cf7647daf981914286d5d32f1beab6d
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/proof/RSA/BN.saw
+++ b/SAW/proof/RSA/BN.saw
@@ -28,7 +28,7 @@ let BN_is_odd_spec num = do {
 
   crucible_execute_func [bn_ptr];
 
-  crucible_return (crucible_term {{ if integerFromBV bn % 2 == 1 then (1 : [32]) else 0 }});
+  crucible_return (crucible_term {{ if (integerFromBV bn) % 2 == 1 then (1 : [32]) else 0 }});
 };
 
 bn_uadd_consttime_n_p_ov <- crucible_llvm_unsafe_assume_spec
@@ -169,13 +169,7 @@ BN_num_bits_e_bits_ov <- llvm_verify m "BN_num_bits"
   (BN_num_bits_spec 17)
   (w4_unint_z3 []);
 
-// BN_is_odd_ov <- llvm_verify m "BN_is_odd"
-//  []
-//  true
-//  (BN_is_odd_spec n_words)
-//  (w4_unint_z3 []);
-
 BN_is_odd_ov <- crucible_llvm_unsafe_assume_spec
   m
   "BN_is_odd"
-  (BN_is_odd_spec n_words);
+  (BN_is_odd_spec e_words);

--- a/SAW/proof/RSA/BN.saw
+++ b/SAW/proof/RSA/BN.saw
@@ -19,6 +19,18 @@ let BN_num_bits_spec num_bits = do {
   crucible_return (crucible_term {{ `num_bits : [32] }});
 };
 
+let BN_is_odd_spec num = do {
+  let num_bits = eval_size {| num * 64 |};
+
+  bn_ptr <- crucible_alloc_readonly (llvm_struct "struct.bignum_st");
+  (bn, bn_d_ptr) <- ptr_to_fresh_readonly "bn" (llvm_int num_bits);
+  points_to_bignum_st_same bn_ptr bn_d_ptr num;
+
+  crucible_execute_func [bn_ptr];
+
+  crucible_return (crucible_term {{ if integerFromBV bn % 2 == 1 then (1 : [32]) else 0 }});
+};
+
 bn_uadd_consttime_n_p_ov <- crucible_llvm_unsafe_assume_spec
   m
   "bn_uadd_consttime"
@@ -157,3 +169,13 @@ BN_num_bits_e_bits_ov <- llvm_verify m "BN_num_bits"
   (BN_num_bits_spec 17)
   (w4_unint_z3 []);
 
+// BN_is_odd_ov <- llvm_verify m "BN_is_odd"
+//  []
+//  true
+//  (BN_is_odd_spec n_words)
+//  (w4_unint_z3 []);
+
+BN_is_odd_ov <- crucible_llvm_unsafe_assume_spec
+  m
+  "BN_is_odd"
+  (BN_is_odd_spec n_words);

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -157,6 +157,7 @@ let pointer_to_base_fresh_rsa_st is_ro = do {
   (e_d, e_d_ptr) <- ptr_to_fresh_readonly "e_d" i64;
   points_to_bignum_st_same e_ptr e_d_ptr 1;
   crucible_precond {{ is_num_bits_bn`{17} e_d }};
+  crucible_precond {{ (integerFromBV e_d) % 2 == 1 }};
 
   crucible_points_to (crucible_field ptr "meth") meth_ptr;
   crucible_points_to (crucible_field ptr "n") n_ptr;
@@ -198,6 +199,7 @@ let pointer_to_fresh_rsa_st is_ro is_priv with_crt with_blinding = do {
   (e_d, e_d_ptr) <- ptr_to_fresh_readonly "e_d" i64;
   points_to_bignum_st_same e_ptr e_d_ptr 1;
   crucible_precond {{ is_num_bits_bn`{17} e_d }};
+  crucible_precond {{ (integerFromBV e_d) % 2 == 1 }};
 
   mont_n_ptr <- pointer_to_bn_mont_ctx_st_with_N_d n_words n_d_ptr n_d;
 
@@ -514,6 +516,7 @@ RSA_verify_PKCS1_PSS_mgf1_ov <- llvm_verify
   , EVP_DigestFinal_ex_0x68_ov
   , sha512_block_data_order_spec
   , BN_num_bits_n_bits_ov
+  , BN_is_odd_ov
   , OPENSSL_malloc_ov
   , OPENSSL_free_nonnull_salt_ov
   , OPENSSL_free_null_ov

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -24,6 +24,7 @@ let p_bytes = eval_size {| p_bits / 8 |};
 let p_words = eval_size {| p_bytes / 8 |};
 let salt_len = SHA_DIGEST_LENGTH;
 let salt_len_param = eval_int {{ -1 : [32] }};
+let e_words = 1;
 
 
 /*
@@ -515,7 +516,6 @@ RSA_verify_PKCS1_PSS_mgf1_ov <- llvm_verify
   , EVP_DigestFinal_ex_0x68_ov
   , sha512_block_data_order_spec
   , BN_num_bits_n_bits_ov
-  , BN_is_odd_ov
   , OPENSSL_malloc_ov
   , OPENSSL_free_nonnull_salt_ov
   , OPENSSL_free_null_ov
@@ -658,6 +658,7 @@ RSA_verify_pss_mgf1_ov <- llvm_verify
   , BN_ucmp_gt_n_e_ov
   , BN_num_bits_n_bits_ov
   , BN_num_bits_e_bits_ov
+  , BN_is_odd_ov
   , sha512_block_data_order_spec
   , value_barrier_w_ov
   , ERR_put_error_ov

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -157,7 +157,6 @@ let pointer_to_base_fresh_rsa_st is_ro = do {
   (e_d, e_d_ptr) <- ptr_to_fresh_readonly "e_d" i64;
   points_to_bignum_st_same e_ptr e_d_ptr 1;
   crucible_precond {{ is_num_bits_bn`{17} e_d }};
-  crucible_precond {{ (integerFromBV e_d) % 2 == 1 }};
 
   crucible_points_to (crucible_field ptr "meth") meth_ptr;
   crucible_points_to (crucible_field ptr "n") n_ptr;
@@ -199,7 +198,6 @@ let pointer_to_fresh_rsa_st is_ro is_priv with_crt with_blinding = do {
   (e_d, e_d_ptr) <- ptr_to_fresh_readonly "e_d" i64;
   points_to_bignum_st_same e_ptr e_d_ptr 1;
   crucible_precond {{ is_num_bits_bn`{17} e_d }};
-  crucible_precond {{ (integerFromBV e_d) % 2 == 1 }};
 
   mont_n_ptr <- pointer_to_bn_mont_ctx_st_with_N_d n_words n_d_ptr n_d;
 
@@ -442,6 +440,7 @@ let RSA_verify_pss_mgf1_spec = do {
   global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
 
   (rsa_ptr, n, _d, e, _p, _q) <- pointer_to_fresh_rsa_st false false false false;
+  crucible_precond {{ (integerFromBV e) % 2 == 1 }};
   (msg, msg_ptr) <- ptr_to_fresh_readonly "msg" (llvm_array SHA_DIGEST_LENGTH i8);
   md_ptr <- crucible_alloc_readonly (llvm_struct "struct.env_md_st");
   points_to_env_md_st md_ptr;

--- a/SAW/proof/RSA/evp-function-specs.saw
+++ b/SAW/proof/RSA/evp-function-specs.saw
@@ -119,6 +119,7 @@ let EVP_DigestVerifyFinal_spec num = do {
   evp_pkey_ctx_ptr <- crucible_alloc_readonly (llvm_struct "struct.evp_pkey_ctx_st");
   pkey_ptr <- crucible_alloc (llvm_struct "struct.evp_pkey_st");
   (rsa_ptr, n, _d, e, _p, _q) <- pointer_to_fresh_rsa_st false false false false;
+  crucible_precond {{ (integerFromBV e) % 2 == 1 }};
   points_to_evp_pkey_st pkey_ptr rsa_ptr;
   rsa_pkey_ctx_ptr <- crucible_alloc_readonly (llvm_struct "struct.RSA_PKEY_CTX");
   points_to_RSA_PKEY_CTX rsa_pkey_ctx_ptr digest_ptr;

--- a/SAW/scripts/build_llvm.sh
+++ b/SAW/scripts/build_llvm.sh
@@ -12,6 +12,6 @@ cd build_src/llvm
 export LLVM_COMPILER=clang
 export CC=wllvm
 export CXX=clang++
-cmake -DCMAKE_BUILD_TYPE=Rel ../../../src -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF
+cmake -DCMAKE_BUILD_TYPE=Rel ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS

--- a/SAW/scripts/build_llvm.sh
+++ b/SAW/scripts/build_llvm.sh
@@ -12,5 +12,6 @@ cd build_src/llvm
 export LLVM_COMPILER=clang
 export CC=wllvm
 export CXX=clang++
-cmake -DCMAKE_BUILD_TYPE=Rel ../../../src
-make
+cmake -DCMAKE_BUILD_TYPE=Rel ../../../src -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF
+NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+make -j $NUM_CPU_THREADS

--- a/SAW/scripts/build_x86.sh
+++ b/SAW/scripts/build_x86.sh
@@ -11,5 +11,6 @@ cd build_src/x86
 export CC=clang
 export CXX=clang++
 (cd ../../../src; patch -p1 -r - --forward <"$PATCH"/nomuxrsp.patch || true)
-cmake -DCMAKE_BUILD_TYPE=Rel ../../../src
-make
+cmake -DCMAKE_BUILD_TYPE=Rel ../../../src -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF
+NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+make -j $NUM_CPU_THREADS

--- a/SAW/scripts/build_x86.sh
+++ b/SAW/scripts/build_x86.sh
@@ -11,6 +11,6 @@ cd build_src/x86
 export CC=clang
 export CXX=clang++
 (cd ../../../src; patch -p1 -r - --forward <"$PATCH"/nomuxrsp.patch || true)
-cmake -DCMAKE_BUILD_TYPE=Rel ../../../src -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF
+cmake -DCMAKE_BUILD_TYPE=Rel ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS


### PR DESCRIPTION
New RSA code in latest BoringSSL merge has a new `BN_is_odd` check on the `e` value of rsa. This slight change has caused our proof to fail, so we're going to need new ways to workaround the new `BN_is_odd` function that was introduced and the value of `e` to be odd.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

