### PR TITLE
Let each process use more memory.

### DIFF
--- a/SAW/proof/AES/AES-GCM-check-entrypoint.go
+++ b/SAW/proof/AES/AES-GCM-check-entrypoint.go
@@ -14,7 +14,7 @@ import (
 
 // Due to memory usage (each select_check takes 8GB memory) and limit of container size (largest one has 145GB memory).
 // |aes_gcm_process_limit| is needed here to limit the number of saw processes.
-const aes_gcm_process_limit int = 20
+const aes_gcm_process_limit int = 15
 
 func main() {
 	log.Printf("Started AES-GCM check.")

--- a/SAW/proof/SHA512/SHA512-384-check-entrypoint.go
+++ b/SAW/proof/SHA512/SHA512-384-check-entrypoint.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 )
 
-const sha_process_limit int = 20
+const sha_process_limit int = 15
 
 func main() {
 	log.Printf("Started SHA512-384 check.")


### PR DESCRIPTION
Background: Formal verification needs more memory than before. With this change, the select check of formal verification can take 2h11min.
https://github.com/awslabs/aws-lc-verification/pull/51#issuecomment-889426900

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

