### PR TITLE
Add parameter range config of AES-GCM select check.

### DIFF
--- a/SAW/proof/AES/AES-GCM-check-entrypoint.go
+++ b/SAW/proof/AES/AES-GCM-check-entrypoint.go
@@ -24,11 +24,13 @@ func main() {
 		utility.RunSawScript("verify-AES-GCM-quickcheck.saw")
 		return
 	}
+	selectcheck_range_start := utility.ParseSelectCheckRange("AES_GCM_SELECTCHECK_START", 1)
+	selectcheck_range_end := utility.ParseSelectCheckRange("AES_GCM_SELECTCHECK_END", 384)
 	// When 'AES_GCM_SELECTCHECK' is defined, formal verification is executed with different `evp_cipher_update_len`.
 	// Generate saw scripts based on the verification template and evp_cipher_update_len range [1, 384].
 	var wg sync.WaitGroup
 	process_count := 0
-	for i := 1; i <= 384; i++ {
+	for i := selectcheck_range_start; i <= selectcheck_range_end; i++ {
 		wg.Add(1)
 		saw_template := "verify-AES-GCM-selectcheck-template.txt"
 		placeholder_name := "TARGET_LEN_PLACEHOLDER"

--- a/SAW/proof/common/utility.go
+++ b/SAW/proof/common/utility.go
@@ -23,6 +23,23 @@ func CheckError(e error) {
 	}
 }
 
+// A function to parse select check parameter range.
+// e.g. if the env var |AES_GCM_SELECTCHECK_RANGE_START| is set, this func will parse its value
+func ParseSelectCheckRange(env_var_name string, default_val int) int {
+	env_var_val := os.Getenv(env_var_name)
+	if len(env_var_val) == 0 {
+		return default_val
+	}
+	ret, err := strconv.Atoi(env_var_val)
+	if err != nil {
+		log.Fatal("Failed to convert the value(%s) of env var |%s| to integer.", env_var_val, env_var_name, err)
+	}
+	if ret < 0 {
+		log.Fatal("The value(%s) of env var |%s| cannot be negative", env_var_val, env_var_name)
+	}
+	return ret
+}
+
 // A function to create a saw script, replace `placeholder_key` with value, and then execute the script.
 func CreateAndRunSawScript(path_to_template string, placeholder_key string, value int, wg *sync.WaitGroup) {
 	log.Printf("Start creating saw script for target value %s based on template %s.", value, path_to_template)

--- a/SAW/scripts/run_checks_release.sh
+++ b/SAW/scripts/run_checks_release.sh
@@ -8,6 +8,20 @@ set -ex
 # The following proofs use Release settings in CMake.
 
 # TODO: reenable proof on SHA-256 when resolved https://github.com/awslabs/aws-lc-verification/issues/32
+# If |*_SELECTCHECK| env variable exists, skip quick check of other algorithms.
+if [ ! -z "${SHA512_384_SELECTCHECK}" ]; then
+  (cd proof/SHA512 && go run SHA512-384-check-entrypoint.go)
+  return
+fi
+if [ ! -z "${HMAC_SELECTCHECK}" ]; then
+  (cd proof/HMAC && go run HMAC-check-entrypoint.go)
+  return
+fi
+if [ ! -z "${AES_GCM_SELECTCHECK}" ]; then
+  (cd proof/AES && go run AES-GCM-check-entrypoint.go)
+  return
+fi
+# If |*_SELECTCHECK| env variable does not exist, run quick check of all algorithms.
 (cd proof/SHA512 && go run SHA512-384-check-entrypoint.go)
 saw proof/SHA512/verify-SHA512-512-quickcheck.saw
 (cd proof/HMAC && go run HMAC-check-entrypoint.go)

--- a/SAW/scripts/run_checks_release.sh
+++ b/SAW/scripts/run_checks_release.sh
@@ -9,15 +9,15 @@ set -ex
 
 # TODO: reenable proof on SHA-256 when resolved https://github.com/awslabs/aws-lc-verification/issues/32
 # If |*_SELECTCHECK| env variable exists, skip quick check of other algorithms.
-if [ ! -z "${SHA512_384_SELECTCHECK}" ]; then
+if [ -n "${SHA512_384_SELECTCHECK}" ]; then
   (cd proof/SHA512 && go run SHA512-384-check-entrypoint.go)
   return
 fi
-if [ ! -z "${HMAC_SELECTCHECK}" ]; then
+if [ -n "${HMAC_SELECTCHECK}" ]; then
   (cd proof/HMAC && go run HMAC-check-entrypoint.go)
   return
 fi
-if [ ! -z "${AES_GCM_SELECTCHECK}" ]; then
+if [ -n "${AES_GCM_SELECTCHECK}" ]; then
   (cd proof/AES && go run AES-GCM-check-entrypoint.go)
   return
 fi


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR skips quick check when select check is enabled. It also added parameter range config of AES-GCM select check.

Tests: CryptoAlg-847?selectedConversation=5a3a0fdd-38e5-478e-80c5-7bbc34382c09

