### PR TITLE
Determine the number of AES jobs to run in parallel based on system memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:20.04
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update
-RUN apt-get install -y wget unzip git cmake clang llvm golang python3-pip libncurses5 quilt
+RUN apt-get install -y wget unzip git cmake clang llvm golang python3-pip libncurses5
 RUN pip3 install wllvm
 
 ADD ./SAW/scripts /lc/scripts

--- a/SAW/proof/common/utility.go
+++ b/SAW/proof/common/utility.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 )
 
 // A utility function to terminate this program when err exists.
@@ -97,4 +98,13 @@ func Wait(process_count *int, limit int, wg *sync.WaitGroup) {
 	} else {
 		*process_count = (*process_count) + 1
 	}
+}
+
+func SystemMemory() uint64 {
+	info := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(info)
+	if err != nil {
+		return 0
+	}
+	return uint64(info.Totalram) * uint64(info.Unit)
 }

--- a/SAW/scripts/build_llvm.sh
+++ b/SAW/scripts/build_llvm.sh
@@ -3,9 +3,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-
-
-set -e
+set -ex
 
 BUILD_TYPE=$1
 
@@ -14,6 +12,6 @@ cd build_src/llvm
 export LLVM_COMPILER=clang
 export CC=wllvm
 export CXX=clang++
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ../../../src
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS

--- a/SAW/scripts/build_llvm.sh
+++ b/SAW/scripts/build_llvm.sh
@@ -12,6 +12,6 @@ cd build_src/llvm
 export LLVM_COMPILER=clang
 export CC=wllvm
 export CXX=clang++
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF ../../../src
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_LIBSSL=OFF ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS

--- a/SAW/scripts/build_x86.sh
+++ b/SAW/scripts/build_x86.sh
@@ -3,7 +3,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 BUILD_TYPE=$1
 
@@ -11,6 +11,6 @@ mkdir -p build_src/x86
 cd build_src/x86
 export CC=clang
 export CXX=clang++
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ../../../src
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS

--- a/SAW/scripts/build_x86.sh
+++ b/SAW/scripts/build_x86.sh
@@ -11,6 +11,6 @@ mkdir -p build_src/x86
 cd build_src/x86
 export CC=clang
 export CXX=clang++
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=OFF -DBUILD_LIBSSL=OFF ../../../src
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_LIBSSL=OFF ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS

--- a/SAW/scripts/entrypoint_check.sh
+++ b/SAW/scripts/entrypoint_check.sh
@@ -3,7 +3,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 PATH=/lc/bin:/go/bin:$PATH
 PATCH=$(realpath ./patch)

--- a/SAW/scripts/install.sh
+++ b/SAW/scripts/install.sh
@@ -3,8 +3,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-
-set -e
+set -ex
 
 Z3_URL='https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip'
 YICES_URL='https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz'

--- a/SAW/scripts/post_build.sh
+++ b/SAW/scripts/post_build.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-set -e
+set -ex
 
 mkdir -p build/llvm/crypto build/x86/crypto
 cp build_src/llvm/crypto/crypto_test build/llvm/crypto/crypto_test


### PR DESCRIPTION
Using the BUILD_GENERAL1_2XLARGE CodeBuild hosts with 145 gb of memory this will result in 18 parallel jobs instead of 15 and finish slightly faster. Looking at past runs the maximum memory for 15 jobs was 105 gb leaving 40 gb (and a lot of CPU cores free). This will also let developers with smaller pools of memory run the tests using the same process as the AWS-LC CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

