### PR TITLE
Install saw when new version is defined.

### DIFF
--- a/SAW/scripts/install.sh
+++ b/SAW/scripts/install.sh
@@ -7,7 +7,8 @@ set -ex
 
 Z3_URL='https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip'
 YICES_URL='https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz'
-SAW_URL='https://saw.galois.com/builds/nightly/saw_unbounded-0.8.0.99-2021-10-11-Linux-x86_64.tar.gz'
+TARGET_SAW_VERSION='0.8.0.99'
+SAW_URL="https://saw.galois.com/builds/nightly/saw_unbounded-${TARGET_SAW_VERSION}-2021-10-11-Linux-x86_64.tar.gz"
 
 mkdir -p bin deps
 
@@ -30,11 +31,24 @@ then
     cp deps/yices/*/bin/yices-smt2 bin/yices-smt2
 fi
 
-# fetch SAW
-if [ ! -f bin/saw ]
-then
+# fetch SAW when not exist.
+install_saw () {
+    rm -rf bin/saw
     mkdir -p deps/saw
     wget $SAW_URL -O deps/saw.tar.gz
     tar -x -f deps/saw.tar.gz --one-top-level=deps/saw
-    cp deps/saw/*/bin/saw bin/saw
+    cp -r deps/saw/*/bin/saw bin/saw
+}
+# fetch SAW when it's not installed.
+if [ ! -f bin/saw ]
+then
+    install_saw
+fi
+# fetch SAW when new version saw is defined.
+INSTALLED_VERSION="$(/bin/saw --version 2>&1)"
+if case ${INSTALLED_VERSION} in "${TARGET_SAW_VERSION}"*) true;; *) false;; esac; then
+    echo "${INSTALLED_VERSION} matches ${TARGET_SAW_VERSION}."
+else
+    echo "${INSTALLED_VERSION} does not match ${TARGET_SAW_VERSION}. Install ${TARGET_SAW_VERSION}."
+    install_saw
 fi


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Description

This PR is to install saw when new version is defined. aws-lc CI will call the `install.sh` script to avoid rebuild related Docker image. 

### Tests

#### Env with target saw installed
```
+ cd /
+ /codebuild/output/src416932631/src/github.com/bryce-shang/aws-lc-verification-build/SAW/scripts/install.sh
+ Z3_URL=https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip
+ YICES_URL=https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz
+ TARGET_SAW_VERSION=0.9.0.99
+ SAW_URL=https://saw.galois.com/builds/nightly/saw-0.9.0.99-2022.03.17-Linux-x86_64.tar.gz
+ mkdir -p bin deps
+ [ ! -f bin/z3 ]
+ [ ! -f bin/yices ]
+ [ ! -f bin/saw ]
+ /bin/saw --version
+ INSTALLED_VERSION=0.9.0.99 (bc564dd)
+ true
+ echo 0.9.0.99 (bc564dd) matches 0.9.0.99.
0.9.0.99 (bc564dd) matches 0.9.0.99.
```

#### Env without target saw installed
```


+ cd /
--
46 | + /codebuild/output/src373434788/src/github.com/bryce-shang/aws-lc-verification-build/SAW/scripts/install.sh
47 | + Z3_URL=https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip
48 | + YICES_URL=https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz
49 | + TARGET_SAW_VERSION=0.9.0.99
50 | + SAW_URL=https://saw.galois.com/builds/nightly/saw-0.9.0.99-2022.03.17-Linux-x86_64.tar.gz
51 | + mkdir -p bin deps
52 | + [ ! -f bin/z3 ]
53 | + [ ! -f bin/yices ]
54 | + [ ! -f bin/saw ]
55 | + /bin/saw --version
56 | + INSTALLED_VERSION=0.8.0.99 (07cffd4)
57 | + false
58 | + echo 0.8.0.99 (07cffd4) does not match 0.9.0.99. Install 0.9.0.99.
59 | 0.8.0.99 (07cffd4) does not match 0.9.0.99. Install 0.9.0.99.
60 | + install_saw
61 | + mkdir -p deps/saw
62 | + wget https://saw.galois.com/builds/nightly/saw-0.9.0.99-2022.03.17-Linux-x86_64.tar.gz -O deps/saw.tar.gz
63 | --2022-03-22 19:41:13--  https://saw.galois.com/builds/nightly/saw-0.9.0.99-2022.03.17-Linux-x86_64.tar.gz
64 | Resolving saw.galois.com (saw.galois.com)... 64.16.52.142
65 | Connecting to saw.galois.com (saw.galois.com)\|64.16.52.142\|:443... connected.
66 | HTTP request sent, awaiting response... 200 OK
67 | Length: 58946326 (56M) [application/x-gzip]
68 | Saving to: 'deps/saw.tar.gz'
69 |  
70 | 0K .......... .......... .......... .......... ..........  0% 1.98M 28s
71 | 50K .......... .......... .......... .......... ..........  0% 1.97M 28s
72 | 100K .......... .......... .......... .......... ..........  0% 3.90M 24s


```
