### PR TITLE
Fix changes incurred by changes to EVP_CIPHER

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = upstream-merge-2022-08-02
-	url = https://github.com/nebeid/aws-lc.git
+	branch = fix-fv-upstream-merge-2022-08-02-nebeid
+	url = https://github.com/awslabs/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = main
-	url = https://github.com/awslabs/aws-lc.git
+	branch = upstream-merge-2022-08-02
+	url = https://github.com/nebeid/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -247,7 +247,7 @@ aes_gcm_from_cipher_ctx_ov <- crucible_llvm_unsafe_assume_spec
   aes_gcm_from_cipher_ctx_spec;
 
 
-llvm_verify m "aes_256_gcm_generic_init" [] true aes_256_gcm_generic_init_spec (w4_unint_yices []);
+llvm_verify m "EVP_aes_256_gcm_init" [] true EVP_aes_256_gcm_init_spec (w4_unint_yices []);
 
 
 let evp_cipher_ovs =
@@ -308,4 +308,3 @@ llvm_verify m "EVP_DecryptFinal_ex"
   true
   (EVP_DecryptFinal_ex_spec evp_cipher_final_gcm_len)
   evp_cipher_tactic;
-

--- a/SAW/proof/AES/evp-function-specs.saw
+++ b/SAW/proof/AES/evp-function-specs.saw
@@ -4,12 +4,12 @@
 */
 
 
-// Specification of aes_256_gcm_generic_init, the initialization function
-// for aes_256_gcm_generic_storage.
-let aes_256_gcm_generic_init_spec = do {
-  crucible_alloc_global "aes_256_gcm_generic_storage";
+// Specification of EVP_aes_256_gcm_init, the initialization function
+// for EVP_aes_256_gcm_storage.
+let EVP_aes_256_gcm_init_spec = do {
+  crucible_alloc_global "EVP_aes_256_gcm_storage";
   crucible_execute_func [];
-  points_to_evp_cipher_st (crucible_global "aes_256_gcm_generic_storage");
+  points_to_evp_cipher_st (crucible_global "EVP_aes_256_gcm_storage");
 };
 
 
@@ -133,4 +133,3 @@ let EVP_DecryptFinal_ex_spec gcm_len = do {
 
   crucible_return (crucible_term {{ (if ret then 1 else 0) : [32] }});
 };
-


### PR DESCRIPTION
Commit: Remove a layer of indirection from most EVP_CIPHERs, May 26, 2022
https://github.com/google/boringssl/commit/a51821a531eae33f13aea592862476e9429f63e4
`aes_256_gcm_generic_init` no longer exists. Hence, it was renamed in the proofs by removing `generic`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

