### PR TITLE
Remove some field names from structs

### DIFF
--- a/SAW/proof/EVP/EVP_CTX.saw
+++ b/SAW/proof/EVP/EVP_CTX.saw
@@ -31,23 +31,40 @@ let points_to_evp_pkey_method_st
       derive
       paramgen
       ctrl = do {
-  crucible_points_to (crucible_field ptr "pkey_id") (crucible_term {{ `pkey_id : [32] }});
-  crucible_points_to (crucible_field ptr "init") init;
-  crucible_points_to (crucible_field ptr "copy") copy;
-  crucible_points_to (crucible_field ptr "cleanup") cleanup;
-  crucible_points_to (crucible_field ptr "keygen") keygen;
-  crucible_points_to (crucible_field ptr "sign_init") sign_init;
-  crucible_points_to (crucible_field ptr "sign") sign;
-  crucible_points_to (crucible_field ptr "sign_message") sign_message;
-  crucible_points_to (crucible_field ptr "verify_init") verify_init;
-  crucible_points_to (crucible_field ptr "verify") verify;
-  crucible_points_to (crucible_field ptr "verify_message") verify_message;
-  crucible_points_to (crucible_field ptr "verify_recover") verify_recover;
-  crucible_points_to (crucible_field ptr "encrypt") encrypt;
-  crucible_points_to (crucible_field ptr "decrypt") decrypt;
-  crucible_points_to (crucible_field ptr "derive") derive;
-  crucible_points_to (crucible_field ptr "paramgen") paramgen;
-  crucible_points_to (crucible_field ptr "ctrl") ctrl;
+  //pkey_id
+  crucible_points_to (crucible_elem ptr 0) (crucible_term {{ `pkey_id : [32] }});
+  //init
+  crucible_points_to (crucible_elem ptr 1) init;
+  //copy
+  crucible_points_to (crucible_elem ptr 2) copy;
+  //cleanup
+  crucible_points_to (crucible_elem ptr 3) cleanup;
+  //keygen
+  crucible_points_to (crucible_elem ptr 4) keygen;
+  //sign_init
+  crucible_points_to (crucible_elem ptr 5) sign_init;
+  //sign
+  crucible_points_to (crucible_elem ptr 6) sign;
+  //sign_message
+  crucible_points_to (crucible_elem ptr 7) sign_message;
+  //verify_init
+  crucible_points_to (crucible_elem ptr 8) verify_init;
+  //verify
+  crucible_points_to (crucible_elem ptr 9) verify;
+  //verify_message
+  crucible_points_to (crucible_elem ptr 10) verify_message;
+  //verify_recover
+  crucible_points_to (crucible_elem ptr 11) verify_recover;
+  //encrypt
+  crucible_points_to (crucible_elem ptr 12) encrypt;
+  //decrypt
+  crucible_points_to (crucible_elem ptr 13) decrypt;
+  //derive
+  crucible_points_to (crucible_elem ptr 14) derive;
+  //paramgen
+  crucible_points_to (crucible_elem ptr 15) paramgen;
+  //ctrl
+  crucible_points_to (crucible_elem ptr 16) ctrl;
 };
 
 let points_to_EVP_PKEY_rsa_pkey_meth ptr = points_to_evp_pkey_method_st

--- a/SAW/proof/SHA512/SHA512-common.saw
+++ b/SAW/proof/SHA512/SHA512-common.saw
@@ -269,14 +269,22 @@ let pointer_to_fresh_sha512_state_st_array name = do {
 
 // Specify the env_md_st struct
 let points_to_env_md_st ptr = do {
-  crucible_points_to (crucible_field ptr "type") (crucible_term {{ `NID : [32] }});
-  crucible_points_to (crucible_field ptr "md_size") (crucible_term {{ `SHA_DIGEST_LENGTH : [32] }});
-  crucible_points_to (crucible_field ptr "flags") (crucible_term {{ 0 : [32] }});
-  crucible_points_to (crucible_field ptr "init") (crucible_global SHA_INIT);
-  crucible_points_to (crucible_field ptr "update") (crucible_global SHA_UPDATE);
-  crucible_points_to (crucible_field ptr "final") (crucible_global SHA_FINAL);
-  crucible_points_to (crucible_field ptr "block_size") (crucible_term {{ `SHA512_CBLOCK : [32] }});
-  crucible_points_to (crucible_field ptr "ctx_size") (crucible_term {{ `SHA512_CTX_SIZE : [32] }});
+  //type
+  crucible_points_to (crucible_elem ptr 0) (crucible_term {{ `NID : [32] }});
+  //md_size
+  crucible_points_to (crucible_elem ptr 1) (crucible_term {{ `SHA_DIGEST_LENGTH : [32] }});
+  //flags
+  crucible_points_to (crucible_elem ptr 2) (crucible_term {{ 0 : [32] }});
+  //init
+  crucible_points_to (crucible_elem ptr 3) (crucible_global SHA_INIT);
+  //update
+  crucible_points_to (crucible_elem ptr 4) (crucible_global SHA_UPDATE);
+  //final
+  crucible_points_to (crucible_elem ptr 5) (crucible_global SHA_FINAL);
+  //block_size
+  crucible_points_to (crucible_elem ptr 6) (crucible_term {{ `SHA512_CBLOCK : [32] }});
+  //ctx_size
+  crucible_points_to (crucible_elem ptr 7) (crucible_term {{ `SHA512_CTX_SIZE : [32] }});
 };
 
 // Specify the env_md_ctx_st struct
@@ -290,8 +298,10 @@ let points_to_env_md_ctx_st ptr digest_ptr md_data_ptr = do {
 };
 
 let points_to_evp_md_pctx_ops ptr = do {
-  crucible_points_to (crucible_field ptr "free") (crucible_global "EVP_PKEY_CTX_free");
-  crucible_points_to (crucible_field ptr "dup") (crucible_global "EVP_PKEY_CTX_dup");
+  //free
+  crucible_points_to (crucible_elem ptr 0) (crucible_global "EVP_PKEY_CTX_free");
+  //dup
+  crucible_points_to (crucible_elem ptr 1) (crucible_global "EVP_PKEY_CTX_dup");
 };
 
 let pointer_to_evp_md_pctx_ops = do {


### PR DESCRIPTION
A recent [change](https://github.com/awslabs/aws-lc/pull/590) to the upstream repo of AWS-LC caused the compiler to remove some field names from structs in the optimized build. This change removes the references to those names from the proofs and uses offsets instead. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

