### PR TITLE
Fixing verify_final_with_length to use withLength

### DIFF
--- a/SAW/proof/SHA512/SHA512.saw
+++ b/SAW/proof/SHA512/SHA512.saw
@@ -187,7 +187,7 @@ let verify_final_with_length withLength = do {
     , OPENSSL_cleanse_ov
     ]
     true
-    (EVP_DigestFinal_array_spec true)
+    (EVP_DigestFinal_array_spec withLength)
     (do {
       goal_eval_unint ["processBlock_Common"];
       simplify (addsimps [arrayUpdate_arrayCopy_thm, arraySet_zero_thm] empty_ss);


### PR DESCRIPTION
The original verify_final_with_length doesn't use the input withLength, therefore resulting in the same condition being checked twice. Fixing it to use withLength so that it checks both cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

