### PR TITLE
Add EVP_PKEY_hkdf_pkey for ECDSA, ECDH and RSA proofs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src"]
 	path = src
-	branch = fix-fv-upstream-merge-2022-08-02-nebeid
+	branch = add-evp-hkdf-to-fips
 	url = https://github.com/awslabs/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs

--- a/SAW/proof/EC/EC.saw
+++ b/SAW/proof/EC/EC.saw
@@ -34,6 +34,7 @@ let points_to_AWSLC_fips_evp_pkey_methods = do {
   crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.0") (crucible_global "EVP_PKEY_rsa_pkey_meth_storage");
   crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.1") (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.2") (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
+  crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.3") (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
 };
 
 
@@ -741,30 +742,37 @@ let AWSLC_fips_evp_pkey_methods_init_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
 
   crucible_execute_func [];
 
   points_to_EVP_PKEY_rsa_pkey_meth (crucible_global "EVP_PKEY_rsa_pkey_meth_storage");
   points_to_EVP_PKEY_rsa_pss_pkey_meth (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
+  points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
   points_to_AWSLC_fips_evp_pkey_methods;
 };
 let AWSLC_fips_evp_pkey_methods_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   crucible_execute_func
@@ -775,6 +783,7 @@ let AWSLC_fips_evp_pkey_methods_spec = do {
   points_to_EVP_PKEY_rsa_pkey_meth (crucible_global "EVP_PKEY_rsa_pkey_meth_storage");
   points_to_EVP_PKEY_rsa_pss_pkey_meth (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
+  points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
   points_to_AWSLC_fips_evp_pkey_methods;
 };
 
@@ -1208,6 +1217,7 @@ llvm_verify m "AWSLC_fips_evp_pkey_methods_init"
   [ EVP_PKEY_rsa_pkey_meth_ov
   , EVP_PKEY_rsa_pss_pkey_meth_ov
   , EVP_PKEY_ec_pkey_meth_ov
+  , EVP_PKEY_hkdf_pkey_meth_ov
   ]
   true
   AWSLC_fips_evp_pkey_methods_init_spec

--- a/SAW/proof/ECDH/evp-function-specs.saw
+++ b/SAW/proof/ECDH/evp-function-specs.saw
@@ -8,12 +8,15 @@ let EVP_PKEY_CTX_new_id_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   crucible_execute_func [(crucible_term {{ `EVP_PKEY_EC : [32] }}), crucible_null];
@@ -26,12 +29,15 @@ let EVP_PKEY_CTX_new_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   pkey_ptr <- crucible_alloc (llvm_struct "struct.evp_pkey_st");

--- a/SAW/proof/ECDSA/evp-function-specs.saw
+++ b/SAW/proof/ECDSA/evp-function-specs.saw
@@ -10,12 +10,15 @@ let EVP_DigestSignVerifyInit_spec is_sign = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   ctx_ptr <- crucible_alloc (llvm_struct "struct.env_md_ctx_st");

--- a/SAW/proof/EVP/EVP_CTX.saw
+++ b/SAW/proof/EVP/EVP_CTX.saw
@@ -10,7 +10,8 @@ let NID_rsassaPss = 912;
 let EVP_PKEY_RSA_PSS = NID_rsassaPss;
 let NID_X9_62_id_ecPublicKey = 408;
 let EVP_PKEY_EC = NID_X9_62_id_ecPublicKey;
-
+let NID_HKDF = 969;
+let EVP_PKEY_HKDF = NID_HKDF;
 
 let points_to_evp_pkey_method_st
       ptr
@@ -130,6 +131,27 @@ let points_to_EVP_PKEY_ec_pkey_meth ptr = points_to_evp_pkey_method_st
       (crucible_global "pkey_ec_ctrl") // ctrl
       ;
 
+let points_to_EVP_PKEY_hkdf_pkey_meth ptr = points_to_evp_pkey_method_st
+      ptr
+      EVP_PKEY_HKDF // pkey_id
+      (crucible_global "pkey_hkdf_init") // init
+      (crucible_global "pkey_hkdf_copy") // copy
+      (crucible_global "pkey_hkdf_cleanup") // cleanup
+      crucible_null // keygen
+      crucible_null // sign_init
+      crucible_null // sign
+      crucible_null // sign_message
+      crucible_null // verify_init
+      crucible_null // verify
+      crucible_null // verify_message
+      crucible_null // verify_recover
+      crucible_null // encrypt
+      crucible_null // decrypt
+      (crucible_global "pkey_hkdf_derive") // derive
+      crucible_null // paramgen
+      (crucible_global "pkey_hkdf_ctrl") // ctrl
+;
+
 
 // Specification of `EVP_PKEY_rsa_pkey_meth_init`, the initialization
 // function for `EVP_PKEY_rsa_pkey_meth_storage`.
@@ -182,6 +204,22 @@ let EVP_PKEY_ec_pkey_meth_spec = do {
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
 };
 
+// Specification of `EVP_PKEY_hkdf_pkey_meth_init`, the initialization function
+// for `EVP_PKEY_hkdf_pkey_meth_storage`.
+let EVP_PKEY_hkdf_pkey_meth_init_spec = do {
+crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+crucible_execute_func [];
+points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+};
+let EVP_PKEY_hkdf_pkey_meth_spec = do {
+crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
+crucible_execute_func
+[ (crucible_global "EVP_PKEY_hkdf_pkey_meth_once")
+, (crucible_global "EVP_PKEY_hkdf_pkey_meth_init")
+];
+points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Proof commands
@@ -204,3 +242,8 @@ EVP_PKEY_ec_pkey_meth_ov <- llvm_unsafe_assume_spec
   "CRYPTO_once"
   EVP_PKEY_ec_pkey_meth_spec;
 
+llvm_verify m "EVP_PKEY_hkdf_pkey_meth_init" [] true EVP_PKEY_hkdf_pkey_meth_init_spec (w4_unint_z3 []);
+EVP_PKEY_hkdf_pkey_meth_ov <- llvm_unsafe_assume_spec
+m
+"CRYPTO_once"
+EVP_PKEY_hkdf_pkey_meth_spec;

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -65,6 +65,7 @@ let points_to_AWSLC_fips_evp_pkey_methods = do {
   crucible_points_to (crucible_elem (crucible_field (crucible_global "AWSLC_fips_evp_pkey_methods_storage") "methods") 0) (crucible_global "EVP_PKEY_rsa_pkey_meth_storage");
   crucible_points_to (crucible_elem (crucible_field (crucible_global "AWSLC_fips_evp_pkey_methods_storage") "methods") 1) (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   crucible_points_to (crucible_elem (crucible_field (crucible_global "AWSLC_fips_evp_pkey_methods_storage") "methods") 2) (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
+  crucible_points_to (crucible_elem (crucible_field (crucible_global "AWSLC_fips_evp_pkey_methods_storage") "methods") 3) (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
 };
 
 let pointer_to_evp_pkey_method_st = do {
@@ -328,9 +329,11 @@ let AWSLC_fips_evp_pkey_methods_init_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage";
 
   crucible_execute_func [];
@@ -338,15 +341,18 @@ let AWSLC_fips_evp_pkey_methods_init_spec = do {
   points_to_EVP_PKEY_rsa_pkey_meth (crucible_global "EVP_PKEY_rsa_pkey_meth_storage");
   points_to_EVP_PKEY_rsa_pss_pkey_meth (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
+  points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
   points_to_AWSLC_fips_evp_pkey_methods;
 };
 let AWSLC_fips_evp_pkey_methods_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
@@ -358,6 +364,7 @@ let AWSLC_fips_evp_pkey_methods_spec = do {
   points_to_EVP_PKEY_rsa_pkey_meth (crucible_global "EVP_PKEY_rsa_pkey_meth_storage");
   points_to_EVP_PKEY_rsa_pss_pkey_meth (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
+  points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
   points_to_AWSLC_fips_evp_pkey_methods;
 };
 
@@ -526,6 +533,7 @@ llvm_verify m "AWSLC_fips_evp_pkey_methods_init"
   [ EVP_PKEY_rsa_pkey_meth_ov
   , EVP_PKEY_rsa_pss_pkey_meth_ov
   , EVP_PKEY_ec_pkey_meth_ov
+  , EVP_PKEY_hkdf_pkey_meth_ov
   ]
   true
   AWSLC_fips_evp_pkey_methods_init_spec

--- a/SAW/proof/RSA/evp-function-specs.saw
+++ b/SAW/proof/RSA/evp-function-specs.saw
@@ -10,9 +10,11 @@ let EVP_DigestSignVerifyInit_spec is_sign = do {
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Changes:
1. Update tracking of submodule src to be branch add-evp-hkdf-to-fips
2. Adding the precondition for `EVP_PKEY_hkdf_pkey_meth`
3. Fix proofs for ECDSA, ECDH and RSA to use updated precondition
