### PR TITLE
Fixing stack trace to be stack frame

### DIFF
--- a/SAW/scripts/parallel.py
+++ b/SAW/scripts/parallel.py
@@ -54,7 +54,7 @@ def create_summary(output, error, exit_code, debug):
     for l in output:
         if not debug:
             if not l or re.match(pattern, l): continue
-            if "Stack trace" in l: break
+            if "Stack frame" in l: break
         summary.append(l)
     if error: summary.append(error)
     summary.append("Exit {}".format(exit_code))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Note:
Change the output to only disable the stack frame instead of the whole stack trace.
