### PR TITLE
Increase memory_used_per_test in AES-GCM selectcheck proofs

### DIFF
--- a/SAW/proof/AES/AES-GCM-check-entrypoint.go
+++ b/SAW/proof/AES/AES-GCM-check-entrypoint.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 )
 
-// The AES GCM proofs use approximately 7 gb of memory each, round up to 8 gb for headroom
-const memory_used_per_test uint64 = 8e9
+// The AES GCM proofs use approximately 8 gb of memory each, using 9 gb for headroom
+const memory_used_per_test uint64 = 9e9
 
 func main() {
 	log.Printf("Started AES-GCM check.")


### PR DESCRIPTION
Problem:
AES-GCM selectcheck is failing in AWS-LC CI due to resource exhaustion. 

Solution:
Increase memory use per test variable to reduce parallelism.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

