### PR TITLE
Fix process limit calculation

### DIFF
--- a/SAW/proof/AES/AES-GCM-check-entrypoint.go
+++ b/SAW/proof/AES/AES-GCM-check-entrypoint.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 )
 
-// The AES GCM proofs use approximately 8 gb of memory each, using 9 gb for headroom
+// The AES GCM proofs use more than 8.2 gb of memory each, using 9 gb for headroom
 const memory_used_per_test uint64 = 9e9
 
 func main() {

--- a/SAW/proof/common/utility.go
+++ b/SAW/proof/common/utility.go
@@ -91,8 +91,9 @@ func RunSawScript(path_to_saw_file string) {
 
 // A function to limit number of concurrent processes.
 func Wait(process_count *int, limit int, wg *sync.WaitGroup) {
-	if *process_count >= limit {
-		log.Printf("Count [%d] reached process limit [%d].", *process_count, limit)
+	// process_count starts from 0, therefore comparing it with limit-1
+	if *process_count >= limit-1 {
+		log.Printf("Count [%d] reached process limit [%d].", *process_count+1, limit)
 		wg.Wait()
 		*process_count = 0
 	} else {

--- a/SAW/proof/common/utility.go
+++ b/SAW/proof/common/utility.go
@@ -91,7 +91,7 @@ func RunSawScript(path_to_saw_file string) {
 
 // A function to limit number of concurrent processes.
 func Wait(process_count *int, limit int, wg *sync.WaitGroup) {
-	// process_count starts from 0, therefore comparing it with limit-1
+	// *process_count starts from 0, therefore comparing it with limit-1
 	if *process_count >= limit-1 {
 		log.Printf("Count [%d] reached process limit [%d].", *process_count+1, limit)
 		wg.Wait()
@@ -107,5 +107,5 @@ func SystemMemory() uint64 {
 	if err != nil {
 		return 0
 	}
-	return uint64(info.Totalram) * uint64(info.Unit)
+	return uint64(info.Freeram) * uint64(info.Unit)
 }


### PR DESCRIPTION
1. Fixing an issue that the number of concurrent processes is one larger than the allowed limit.
2. Use Freeram to decide process limit instead of Totalram

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

