### PR TITLE
Expect 64-bit type not 32-bit type

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = main
-	url = https://github.com/awslabs/aws-lc.git
+	branch = rsa_blinding_to_size_t
+	url = https://github.com/torben-hansen/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -452,7 +452,7 @@ let rsa_blinding_get_spec = do {
 
 let rsa_blinding_release_spec = do {
   (rsa_ptr, _, _) <- pointer_to_base_fresh_rsa_st true;
-  index_used <- crucible_fresh_var "index_used" i32;
+  index_used <- crucible_fresh_var "index_used" i64;
   blinding_ptr <- crucible_alloc (llvm_struct "struct.bn_blinding_st");
 
   crucible_execute_func [rsa_ptr, blinding_ptr, (crucible_term index_used)];

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -425,7 +425,7 @@ let rsa_blinding_get_spec = do {
   crucible_ghost_value rsa_blinding_factor a;
 
   (rsa_ptr, n, e) <- pointer_to_base_fresh_rsa_st true;
-  index_used_ptr <- crucible_alloc i32;
+  index_used_ptr <- crucible_alloc i64;
   ctx_ptr <- pointer_to_bignum_ctx;
 
   crucible_execute_func [rsa_ptr, index_used_ptr, ctx_ptr];

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -444,7 +444,7 @@ let rsa_blinding_get_spec = do {
   crucible_points_to (crucible_field ret_ptr "counter") (crucible_term {{ 0 : [32] }});
 
 
-  index_used <- crucible_fresh_var "index_used" i32;
+  index_used <- crucible_fresh_var "index_used" i64;
   crucible_points_to index_used_ptr (crucible_term index_used);
 
   crucible_return ret_ptr;


### PR DESCRIPTION
#### Issue

CryptoAlg-1440

#### Description of changes

https://github.com/awslabs/aws-lc/pull/699 modifies the signature of `rsa_blinding_release()` to use the type `size_t` instead of `unsigned`. The former normally a 64-bit value (on 64-bit system) while the latter would typically be a 32-bit value.

Switched module to a branch on my local fork to test fix. Need to revert this afterwards.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

