### PR TITLE
Flip submodule back to AWS-LC main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = rsa_blinding_to_size_t
-	url = https://github.com/torben-hansen/aws-lc.git
+	branch = main
+	url = https://github.com/awslabs/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative


### PR DESCRIPTION
#### Issue

P76400167

#### Description

Flipping back submodule after https://github.com/awslabs/aws-lc/commit/cc0ad0c9efc752290ffe3ab0786d322d687770bb commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

