### PR TITLE
Flip src back to AWS-LC main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = fix-gcc-ubuntu
-	url = https://github.com/samuel40791765/aws-lc.git
+	branch = main
+	url = https://github.com/awslabs/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative


### PR DESCRIPTION
**Issue**: 
P80033931

**Description**: 
Flipping src back to AWS-LC main branch after merging of [aws-lc PR #755](https://github.com/awslabs/aws-lc/pull/755)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

