### PR TITLE
Adding a CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AWS LibCrypto Formal Verification
 
+[![.github/workflows/main.yml](https://github.com/awslabs/aws-lc-verification/actions/workflows/main.yml/badge.svg)](https://github.com/awslabs/aws-lc-verification/actions/workflows/main.yml)
+
+
 This repository contains specifications, proof scripts, and other artifacts required to formally verify portions of [AWS libcrypto](https://github.com/awslabs/aws-lc). Formal verification is used to locate bugs and increase assurance of the correctness and security of the library.
 
 ## Verified Code


### PR DESCRIPTION
Adding a CI status badge to allow convenient monitoring of the CI runs and quick reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

