### PR TITLE
Update go verison used in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,15 @@
 
 
 FROM ubuntu:20.04
+ENV GOROOT=/usr/local/go
+ENV PATH="$GOROOT/bin:$PATH"
+ARG GO_VERSION=1.20.1
+ARG GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update
-RUN apt-get install -y wget unzip git cmake clang llvm golang python3-pip libncurses5
+RUN apt-get install -y wget unzip git cmake clang llvm python3-pip libncurses5
+RUN wget "https://dl.google.com/go/${GO_ARCHIVE}" && tar -xvf $GO_ARCHIVE && \
+   mkdir $GOROOT &&  mv go/* $GOROOT && rm $GO_ARCHIVE
 RUN pip3 install wllvm
 
 ADD ./SAW/scripts /lc/scripts


### PR DESCRIPTION
AWS-LC is working to update the version of Go used in our CI to unblock adoption of modern Go features. This change is inspired by how we install a particular version of go in https://github.com/aws/aws-lc/commit/6704d7f793fb95fb4421fcf78f74117df8d10a27.

I considered moving to a newer Ubuntu version which would come with a newer Go version but that would change the compiler as well (Clang 10 to 15) and I am afraid that would create issues with the formal verification.

A ENV command is a variable available during build time and runtime (which we need for goroot and path), while an ARG is only available during build time (and can be overwritten with a CLI parameter if you want to).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

