### PR TITLE
Add an override for `BN_is_odd` when applied to `RSA->n`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = main
-	url = https://github.com/awslabs/aws-lc.git
+	branch = upstream-merge-2023-03-20
+	url = https://github.com/samuel40791765/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/proof/RSA/BN.saw
+++ b/SAW/proof/RSA/BN.saw
@@ -190,7 +190,12 @@ BN_num_bits_e_bits_ov <- llvm_verify m "BN_num_bits"
   (BN_num_bits_spec 17)
   (w4_unint_z3 []);
 
-BN_is_odd_ov <- crucible_llvm_unsafe_assume_spec
+BN_is_odd_e_ov <- crucible_llvm_unsafe_assume_spec
   m
   "BN_is_odd"
   (BN_is_odd_spec e_words);
+
+BN_is_odd_n_ov <- crucible_llvm_unsafe_assume_spec
+  m
+  "BN_is_odd"
+  (BN_is_odd_spec n_words);

--- a/SAW/proof/RSA/RSA.saw
+++ b/SAW/proof/RSA/RSA.saw
@@ -730,7 +730,8 @@ RSA_verify_pss_mgf1_ov <- llvm_verify
   , BN_ucmp_gt_n_e_ov
   , BN_num_bits_n_bits_ov
   , BN_num_bits_e_bits_ov
-  , BN_is_odd_ov
+  , BN_is_odd_e_ov
+  , BN_is_odd_n_ov
   , sha512_block_data_order_ov
   , value_barrier_w_ov
   , ERR_put_error_ov


### PR DESCRIPTION
This PR adds an override for `BN_is_odd` when applied to `RSA->n`.  This is to fix a proof failure.

aws-lc PR: https://github.com/aws/aws-lc/pull/889
ticket: P84020433

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

