### PR TITLE
Add override for OPENSSL_cleanse in proof of HMAC_Init_ex

### DIFF
--- a/SAW/proof/HMAC/verify-HMAC.saw
+++ b/SAW/proof/HMAC/verify-HMAC.saw
@@ -112,7 +112,8 @@ llvm_verify m "HMAC_CTX_init"
 let verify_HMAC_Init_ex_array_spec = do {
   print "Verifying HMAC_Init_ex_array_spec with arbitrary key length.";
   llvm_verify m "HMAC_Init_ex"
-    [ GetInPlaceMethods_ov
+    [ OPENSSL_cleanse_ov
+    , GetInPlaceMethods_ov
     , SHA512_Update_0_SHA512_CBLOCK_ov
     , SHA512_Final_array_ov
     , SHA512_Update_array_ov


### PR DESCRIPTION
This PR adds an override for `OPENSSL_cleanse` in the proof of `HMAC_Init_ex`.

AWS-LC PR: https://github.com/aws/aws-lc/pull/911
Ticket: P84705958

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

