### PR TITLE
Add an override for OPENSSL_cleanse in EVP_PKEY_derive proof

### DIFF
--- a/SAW/proof/ECDH/ECDH.saw
+++ b/SAW/proof/ECDH/ECDH.saw
@@ -143,6 +143,7 @@ llvm_verify m "EVP_PKEY_derive"
   , OPENSSL_malloc_ov
   , EC_KEY_check_fips_ov
   , EC_KEY_free_ov
+  , OPENSSL_cleanse_ov
   ]
   true
   EVP_PKEY_derive_spec


### PR DESCRIPTION
This PR fixes a formal verification failure.

AWS-LC PR: https://github.com/aws/aws-lc/pull/956
Ticket: P86205958

This fix is nonblocking.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

