### PR TITLE
Update global constant pairs used in AES-GCM proofs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = main
-	url = https://github.com/aws/aws-lc.git
+	branch = upstream-merge-2023-04-14
+	url = https://github.com/skmcgrail/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/proof/AES/AESNI-GCM.saw
+++ b/SAW/proof/AES/AESNI-GCM.saw
@@ -61,14 +61,14 @@ add_x86_preserved_reg "rax";
 enable_what4_hash_consing;
 
 aesni_gcm_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aesni_gcm_encrypt"
-  [ ("aesni_gcm_encrypt", 1200) // we need .Lbswap_mask, which lives in .text after aesni_gcm_encrypt (1081 bytes itself). 1200 bytes is an arbitrary size that I guessed would be large enough to contain the right bytes after alignment.
+  [ ("boringssl_self_test_ecc.kP256Scalar", 192) // We need .Lbswap_mask. Its location is <boringssl_self_test_ecc.kP256Scalar+0x50>. 192 bytes is an offset that would be large enough to contain the right bytes after alignment.
   ]
   true
   (aesni_gcm_cipher_spec {{ 1 : [32] }} aesni_gcm_cipher_gcm_len aesni_gcm_cipher_len)
   aesni_gcm_cipher_tactic;
 
 aesni_gcm_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aesni_gcm_decrypt"
-  [ ("aesni_gcm_encrypt", 1200) // we need .Lbswap_mask, which lives in .text after aesni_gcm_encrypt (1081 bytes itself). 1200 bytes is an arbitrary size that I guessed would be large enough to contain the right bytes after alignment.
+  [ ("boringssl_self_test_ecc.kP256Scalar", 192)
   ]
   true
   (aesni_gcm_cipher_spec {{ 0 : [32] }} aesni_gcm_cipher_gcm_len aesni_gcm_cipher_len)
@@ -76,4 +76,3 @@ aesni_gcm_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "
 
 disable_what4_hash_consing;
 default_x86_preserved_reg;
-

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -48,7 +48,14 @@ let gcm_ghash_avx_spec len = do {
 
 enable_what4_hash_consing;
 gcm_init_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_init_avx"
-  [ ("gcm_ghash_avx", 1800) // similar hack to the one in AESNI-GCM.saw to grab .L0x1c2_polynomial, we need a better way to handle this
+  // How to find clues for constructing the global symbol pair?
+  // 1. Find the location of the function "gcm_init_avx" in the assembly
+  //    using "nm crypto_test | grep gcm_init_avx"
+  // 2. Find the instruction that uses the constant -- L0x1c2_polynomial
+  // 3. If there is a comment, then the comment tells us where that constant is;
+  //    else the address should be
+  //      %rip (current_instruction_addr) + 8 (current_instruction_size) + the displacement offset
+  [ ("boringssl_self_test_ecc.kP256Scalar", 640) // We need .L0x1c2_polynomial. Its location is <boringssl_self_test_ecc.kP256Scalar+0x260>. 640 bytes is an offset that would be large enough to contain the right bytes after alignment.
   ]
   true
   gcm_init_avx_spec
@@ -60,7 +67,7 @@ gcm_init_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_i
 disable_what4_hash_consing;
 
 gcm_gmult_avx_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_gmult_avx"
-  [ ("gcm_ghash_avx", 1800)
+  [ ("boringssl_self_test_ecc.kP256Scalar", 640)
   ]
   true
   gcm_gmult_avx_spec
@@ -82,14 +89,14 @@ let gcm_ghash_avx_tactic = do {
 };
 
 gcm_ghash_avx_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
-  [ ("gcm_ghash_avx", 1800)
+  [ ("boringssl_self_test_ecc.kP256Scalar", 640)
   ]
   true
   (gcm_ghash_avx_spec GHASH_length_blocks_encrypt)
   gcm_ghash_avx_tactic;
 
 gcm_ghash_avx_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
-  [ ("gcm_ghash_avx", 1800)
+  [ ("boringssl_self_test_ecc.kP256Scalar", 640)
   ]
   true
   (gcm_ghash_avx_spec GHASH_length_blocks_decrypt)


### PR DESCRIPTION
This PR updates the global constant pairs used in the x86 assembly proofs in AES-GCM. 

AWS-LC PR: https://github.com/aws/aws-lc/pull/958
Ticket: P86220332

This change requires a coordinated merge.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

