### PR TITLE
Upgrade SAW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get install -y wget unzip git cmake clang llvm python3-pip libncurses5
 RUN wget "https://dl.google.com/go/${GO_ARCHIVE}" && tar -xvf $GO_ARCHIVE && \
    mkdir $GOROOT &&  mv go/* $GOROOT && rm $GO_ARCHIVE
 RUN pip3 install wllvm
+RUN pip3 install psutil
 
 ADD ./SAW/scripts /lc/scripts
 RUN /lc/scripts/docker_install.sh

--- a/SAW/proof/HMAC/verify-HMAC.saw
+++ b/SAW/proof/HMAC/verify-HMAC.saw
@@ -109,7 +109,7 @@ llvm_verify m "HMAC_CTX_init"
   (w4_unint_z3 []);
 
 // Verify HMAC_Init_ex_array
-// 4 mins
+// 2 mins
 let verify_HMAC_Init_ex_array_spec = do {
   print "Verifying HMAC_Init_ex_array_spec with arbitrary key length.";
   llvm_verify m "HMAC_Init_ex"
@@ -144,9 +144,11 @@ let verify_HMAC_Init_ex_array_spec = do {
         w4_unint_z3 ["SHAFinal_Array", "SHAUpdate_Array"];
       } else if ar_goal then do {
         goal_eval_unint ["SHAUpdate_Array", "SHAFinal_Array", "SHAUpdate"];
-        simplify (addsimps [arrayRangeEq_ite_commute_thm, arrayCopy_zero_thm] empty_ss);
+        simplify (addsimps [arrayCopy_zero_thm] empty_ss);
+        goal_eval_unint ["SHAUpdate_Array", "SHAFinal_Array", "SHAUpdate"];
+        hoist_ifs_in_goal;
+        goal_eval_unint ["SHAUpdate_Array", "SHAFinal_Array", "SHAUpdate"];
         goal_insert arrayRangeEq_SHAFinal_Array_equivalence_thm;
-        goal_insert ite_of_arrayRangeEq_equivalence_thm;
         w4_unint_z3 ["SHAUpdate_Array", "SHAFinal_Array", "SHAUpdate"];
       } else do {
         goal_eval_unint ["SHAFinal_Array"];

--- a/SAW/proof/SHA512/SHA512-common.saw
+++ b/SAW/proof/SHA512/SHA512-common.saw
@@ -39,6 +39,7 @@ sha512_block_data_order_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_t
     simplify (addsimps thms empty_ss);
     simplify (addsimp concat_assoc_thm empty_ss);
     goal_eval_unint ["S0", "S1", "s0", "s1", "Ch"];
+    simplify (addsimps thms empty_ss);
     w4_unint_z3 ["S0", "S1", "s0", "s1", "Ch"];
   });
 
@@ -59,6 +60,7 @@ sha512_block_data_order_array_ov <- llvm_verify_fixpoint_x86 m "../../build/x86/
     simplify (addsimps thms empty_ss);
     simplify (addsimp concat_assoc_thm empty_ss);
     goal_eval_unint ["processBlocksLoop", "S0", "S1", "s0", "s1", "Ch"];
+    simplify (addsimps thms empty_ss);
     w4_unint_z3 ["processBlocksLoop", "S0", "S1", "s0", "s1", "Ch"];
   });
 

--- a/SAW/proof/SHA512/lemmas.saw
+++ b/SAW/proof/SHA512/lemmas.saw
@@ -6,15 +6,6 @@
 // -------------------------------------------------------
 //                 Array lemmas
 
-print "Proving arrayRangeEq_ite_commute_thm";
-arrayRangeEq_ite_commute_thm <- prove_print
-(w4_unint_z3 [])
-(rewrite (cryptol_ss ())
-{{ \x y p q c ->
-  (arrayRangeEq (if c then x else y) 0 (if c then p else q) 0 128) ==
-  (if c then (arrayRangeEq x 0 p 0 128) else (arrayRangeEq y 0 q 0 128))
-}});
-
 print "Proving ite_of_arrayRangeEq_equivalence_thm";
 ite_of_arrayRangeEq_equivalence_thm <- prove_print
 (w4_unint_z3 [])

--- a/SAW/proof/SHA512/sha512_block_data_order-goal-rewrites.saw
+++ b/SAW/proof/SHA512/sha512_block_data_order-goal-rewrites.saw
@@ -64,32 +64,7 @@ rotate60_thm <- prove_folding_theorem {{ \x -> (slice_60_4_0  x) # (slice_0_60_4
 // These variants of rotate59_thm apply in cases when SAW built-in
 // simplifications prevent rotate59_thm from applying.
 rotate59_slice_add_thm <- prove_folding_theorem
-  {{ \x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48 x49 x50 ->
-      (slice_59_5_0 (x0 + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50))
-        # (slice_0_59_5 (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50))
-      == (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50) <<< 59
-  }};
-
-rotate59_slice_add_1_thm <- prove_folding_theorem
-  {{ \x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 ->
-      (slice_59_5_0 (x0 + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54))
-        # (slice_0_59_5 (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54))
-      == (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54) <<< 59
-  }};
-
-rotate59_slice_add_2_thm <- prove_folding_theorem
-  {{ \x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 ->
-      (slice_59_5_0 (x0 + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54 + x55 + x56 + x57 + x58))
-        # (slice_0_59_5 (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54 + x55 + x56 + x57 + x58))
-      == (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54 + x55 + x56 + x57 + x58) <<< 59
-  }};
-
-rotate59_slice_add_3_thm <- prove_folding_theorem
-  {{ \x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 ->
-      (slice_59_5_0 (x0 + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54 + x55 + x56 + x57 + x58 + x59 + x60 + x61 + x62))
-        # (slice_0_59_5 (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54 + x55 + x56 + x57 + x58 + x59 + x60 + x61 + x62))
-      == (x0 + (64 * x1) + x2 + x3 + x4 + x5 + x6 + x7 +x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 + x26 + x27 + x28 + x29 + x30 + x31 + x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 + x40 + x41 + x42 + x43 + x44 + x45 + x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 + x54 + x55 + x56 + x57 + x58 + x59 + x60 + x61 + x62) <<< 59
-  }};
+  {{ \x y -> (slice_59_5_0 x) # (slice_0_59_5 y) == (y <<< 59) + ((slice_59_5_0 (x - y)) # 0) }};
 
 // This pushes XOR under concatenation.
 xor_append_64_64_thm <- prove_folding_theorem
@@ -97,10 +72,14 @@ xor_append_64_64_thm <- prove_folding_theorem
 
 // These prove that the various sigma functions are equivalent to sequences of
 // ANDs, rotations, and shifts.
-Sigma0_thm   <- prove_folding_theorem {{ \x -> (x ^ ((x ^ (x <<< 59)) <<< 58)) <<< 36 == S0 x }};
-Sigma0_1_thm <- prove_folding_theorem {{ \x -> ((((x <<< 59) ^ x) <<< 58) ^ x) <<< 36 == S0 x }};
-Sigma1_thm   <- prove_folding_theorem {{ \x -> (x ^ ((x ^ (x <<< 41)) <<< 60)) <<< 50 == S1 x }};
-Sigma1_1_thm <- prove_folding_theorem {{ \x -> ((((x <<< 41) ^ x) <<< 60) ^ x) <<< 50 == S1 x }};
+Sigma0_thm   <- prove_folding_theorem
+  (normalize_term_opaque ["S0"] {{ \x -> (x ^ ((x ^ (x <<< 59)) <<< 58)) <<< 36 == S0 x }});
+Sigma0_1_thm <- prove_folding_theorem
+  (normalize_term_opaque ["S0"] {{ \x -> ((((x <<< 59) ^ x) <<< 58) ^ x) <<< 36 == S0 x }});
+Sigma1_thm   <- prove_folding_theorem
+  (normalize_term_opaque ["S1"] {{ \x -> (x ^ ((x ^ (x <<< 41)) <<< 60)) <<< 50 == S1 x }});
+Sigma1_1_thm <- prove_folding_theorem
+  (normalize_term_opaque ["S1"] {{ \x -> ((((x <<< 41) ^ x) <<< 60) ^ x) <<< 50 == S1 x }});
 sigma0_thm <- prove_folding_theorem
   {{ \x -> (bvShr1 x) ^ (bvShr7 x) ^ (bvShl56 x) ^ (bvShr7 (bvShr1 x)) ^ (bvShl7 (bvShl56 x)) == s0 x }};
 sigma1_thm <- prove_folding_theorem
@@ -137,9 +116,6 @@ let thms =
   , rotate59_thm
   , rotate60_thm
   , rotate59_slice_add_thm
-  , rotate59_slice_add_1_thm
-  , rotate59_slice_add_2_thm
-  , rotate59_slice_add_3_thm
   , xor_append_64_64_thm
   , Sigma0_thm
   , Sigma0_1_thm

--- a/SAW/scripts/install.sh
+++ b/SAW/scripts/install.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-SAW_URL='https://saw-builds.s3.us-west-2.amazonaws.com/saw-0.9.0.99-2023-03-03-Linux-x86_64.tar.gz'
+SAW_URL='https://saw-builds.s3.us-west-2.amazonaws.com/saw-0.9.0.99-2023-06-08-ab46c76e0-Linux-x86_64.tar.gz'
 
 mkdir -p /bin /deps
 

--- a/SAW/scripts/parallel.py
+++ b/SAW/scripts/parallel.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 import time
+import psutil
 
 LINEWIDTH = 80
 
@@ -62,8 +63,12 @@ def create_summary(output, error, exit_code, debug):
 
 # Run subprocesses in parallel
 def parallel_run (commands, debug):
+    mem = psutil.virtual_memory().available
+    # Assuming each process uses 7GB memory
+    pmem = 7*1024*1024*1024
+    pbound = int(mem/pmem)
     np = multiprocessing.cpu_count()
-    pool = multiprocessing.Pool(np)
+    pool = multiprocessing.Pool(min(np, pbound))
     with pool as p:
         results = p.map(run_process, commands)
         for res in results:


### PR DESCRIPTION
This PR:

1. Upgrade SAW to be version [ab46c76e0](https://github.com/GaloisInc/saw-script/commit/ab46c76e037e9a50577c15a0b989825aee35ebef)
2. Fix SHA2 and HMAC proofs to work with the new version of SAW
3. Calculate allowed parallelism based on assumed memory usage per job

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

