### PR TITLE
Fix formal verification failure in AWS-LC PR 1177

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = main
-	url = https://github.com/aws/aws-lc.git
+	branch = prepare-ec-unions
+	url = https://github.com/justsmth/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/patch/noinline-p384_get_bit.patch
+++ b/SAW/patch/noinline-p384_get_bit.patch
@@ -1,12 +1,12 @@
 diff --git a/crypto/fipsmodule/ec/p384.c b/crypto/fipsmodule/ec/p384.c
-index 72b93a063..9908e98b5 100644
+index b4c784bb6..e78ab1dad 100644
 --- a/crypto/fipsmodule/ec/p384.c
 +++ b/crypto/fipsmodule/ec/p384.c
-@@ -655,6 +655,7 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
+@@ -649,6 +649,7 @@ static int ec_GFp_nistp384_cmp_x_coordinate(const EC_GROUP *group,
  
  
  // p384_get_bit returns the |i|-th bit in |in|
 +__attribute__((noinline))
- static crypto_word_t p384_get_bit(const uint8_t *in, int i) {
+ static crypto_word_t p384_get_bit(const EC_SCALAR *in, int i) {
    if (i < 0 || i >= 384) {
      return 0;

--- a/SAW/proof/ECDSA/verify-ECDSA.saw
+++ b/SAW/proof/ECDSA/verify-ECDSA.saw
@@ -101,6 +101,7 @@ ECDSA_do_sign_ov <- llvm_verify m "ECDSA_do_sign"
     hoist_ifs_in_goal;
     simplify (addsimps minor_touchup_thms empty_ss);
     simplify (addsimps append_slice_384_thms empty_ss);
+    simplify (addsimp append_slice_384_thm empty_ss);
     simplify (addsimps [add_negate_thm, toInteger_sub_384_thm_1] empty_ss);
     hoist_ifs_in_goal;
     simplify (addsimps minor_touchup_thms empty_ss);


### PR DESCRIPTION
AWS-LC PR: https://github.com/aws/aws-lc/pull/1177
Ticket: V1036647715

Fixes:
1. Updated the patch file noinline-p384_get_bit.patch.
2. Added a rewrite rule for proof of `ECDSA_do_sign`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

