### PR TITLE
Update README to reflect the change in Dockerfile setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ The easiest way to build the library and run the proofs is to use [Docker](https
    1. `git submodule update --init`
    2. `pushd Coq/fiat-crypto; git submodule update --init --recursive; popd`
 
-2. Build a Docker image: `docker build --pull --no-cache -t awslc-saw .`
+2. Build a Docker image:
+   1. For running just SAW proofs: `docker build --pull --no-cache -f Dockerfile.saw -t awslc-saw .`
+   2. For running both SAW and Coq proofs: `docker build --pull --no-cache -f Dockerfile.coq -t awslc-saw .`
+
 3. Run the SAW proofs inside the Docker container: ``docker run -v `pwd`:`pwd` -w `pwd` awslc-saw``
    1. Use Coq to validate the Cryptol specs used in the SAW proofs: ``docker run -it -v `pwd`:`pwd` -w `pwd` --entrypoint Coq/docker_entrypoint.sh awslc-saw``
 


### PR DESCRIPTION
In a recent AWS-LC-verification [PR](https://github.com/awslabs/aws-lc-verification/pull/115), the `Dockerfile` is divided into two (`Dockerfile.saw` for SAW proofs and `Dockerfile.coq` for Coq proofs). Update the docker build instructions in `README` to reflect this change.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

