### PR TITLE
Add support for EVP_PKEY_HMAC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = main
-	url = https://github.com/aws/aws-lc.git
+	branch = evp-pkey-hmac
+	url = https://github.com/samuel40791765/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/proof/EC/EC.saw
+++ b/SAW/proof/EC/EC.saw
@@ -36,6 +36,7 @@ let points_to_AWSLC_fips_evp_pkey_methods = do {
   crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.1") (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.2") (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
   crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.3") (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+  crucible_points_to (crucible_global "AWSLC_fips_evp_pkey_methods_storage.0.4") (crucible_global "EVP_PKEY_hmac_pkey_meth_storage");
 };
 
 
@@ -735,14 +736,17 @@ let AWSLC_fips_evp_pkey_methods_init_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.4";
 
   crucible_execute_func [];
 
@@ -750,6 +754,7 @@ let AWSLC_fips_evp_pkey_methods_init_spec = do {
   points_to_EVP_PKEY_rsa_pss_pkey_meth (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
   points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+  points_to_EVP_PKEY_hmac_pkey_meth (crucible_global "EVP_PKEY_hmac_pkey_meth_storage");
   points_to_AWSLC_fips_evp_pkey_methods;
 };
 let AWSLC_fips_evp_pkey_methods_spec = do {
@@ -757,14 +762,17 @@ let AWSLC_fips_evp_pkey_methods_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.4";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   crucible_execute_func
@@ -776,6 +784,7 @@ let AWSLC_fips_evp_pkey_methods_spec = do {
   points_to_EVP_PKEY_rsa_pss_pkey_meth (crucible_global "EVP_PKEY_rsa_pss_pkey_meth_storage");
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_ec_pkey_meth_storage");
   points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+  points_to_EVP_PKEY_ec_pkey_meth (crucible_global "EVP_PKEY_hmac_pkey_meth_storage");
   points_to_AWSLC_fips_evp_pkey_methods;
 };
 
@@ -1215,6 +1224,7 @@ llvm_verify m "AWSLC_fips_evp_pkey_methods_init"
   , EVP_PKEY_rsa_pss_pkey_meth_ov
   , EVP_PKEY_ec_pkey_meth_ov
   , EVP_PKEY_hkdf_pkey_meth_ov
+  , EVP_PKEY_hmac_pkey_meth_ov
   ]
   true
   AWSLC_fips_evp_pkey_methods_init_spec
@@ -1223,4 +1233,3 @@ AWSLC_fips_evp_pkey_methods_ov <- llvm_unsafe_assume_spec
   m
   "CRYPTO_once"
   AWSLC_fips_evp_pkey_methods_spec;
-

--- a/SAW/proof/ECDH/evp-function-specs.saw
+++ b/SAW/proof/ECDH/evp-function-specs.saw
@@ -10,14 +10,17 @@ let EVP_PKEY_CTX_new_id_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.4";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   crucible_execute_func [(crucible_term {{ `EVP_PKEY_EC : [32] }}), crucible_null];
@@ -31,14 +34,17 @@ let EVP_PKEY_CTX_new_spec = do {
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.4";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   pkey_ptr <- crucible_alloc (llvm_struct "struct.evp_pkey_st");

--- a/SAW/proof/ECDSA/evp-function-specs.saw
+++ b/SAW/proof/ECDSA/evp-function-specs.saw
@@ -11,18 +11,21 @@ let EVP_DigestSignVerifyInit_spec is_sign = do {
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_storage";
   crucible_alloc_global "EVP_PKEY_rsa_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_rsa_pss_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_ec_pkey_meth_once";
   crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_once";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.0";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.1";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.2";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.3";
+  crucible_alloc_global "AWSLC_fips_evp_pkey_methods_storage.0.4";
   crucible_alloc_global "AWSLC_fips_evp_pkey_methods_once";
 
   ctx_ptr <- crucible_alloc (llvm_struct "struct.env_md_ctx_st");
-  points_to_env_md_ctx_st ctx_ptr crucible_null crucible_null;
+  points_to_env_md_ctx_st ctx_ptr crucible_null crucible_null crucible_null;
 
   type_ptr <- crucible_alloc_readonly (llvm_struct "struct.env_md_st");
   points_to_env_md_st type_ptr;
@@ -45,7 +48,7 @@ let EVP_DigestSignVerifyInit_spec is_sign = do {
   ec_pkey_ctx_ptr <- crucible_alloc (llvm_struct "struct.EC_PKEY_CTX");
   points_to_EC_PKEY_CTX ec_pkey_ctx_ptr type_ptr;
   points_to_evp_pkey_ctx_st evp_pkey_ctx_ptr (crucible_global "EVP_PKEY_ec_pkey_meth_storage") pkey_ptr crucible_null (if is_sign then EVP_PKEY_OP_SIGN else EVP_PKEY_OP_VERIFY) ec_pkey_ctx_ptr;
-  points_to_env_md_ctx_st_with_pctx ctx_ptr type_ptr sha512_state_ptr evp_pkey_ctx_ptr (crucible_global "EVP_MD_pctx_ops_storage");
+  points_to_env_md_ctx_st_with_pctx ctx_ptr type_ptr sha512_state_ptr evp_pkey_ctx_ptr (crucible_global "EVP_MD_pctx_ops_storage") (crucible_global SHA_UPDATE);
 
   crucible_return (crucible_term {{ 1 : [32] }});
 };
@@ -73,7 +76,7 @@ let EVP_DigestSignVerifyUpdate_spec is_sign = do {
 
   pctx_ops_ptr <- pointer_to_evp_md_pctx_ops;
 
-  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr;
+  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr (crucible_global SHA_UPDATE);
 
   len <- crucible_fresh_var "len" i64;
   (data, data_ptr) <- ptr_to_fresh_array_readonly "data" len;
@@ -114,7 +117,7 @@ let EVP_DigestSignFinal_spec = do {
 
   pctx_ops_ptr <- pointer_to_evp_md_pctx_ops;
 
-  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr;
+  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr (crucible_global SHA_UPDATE);
 
   out_sig_ptr <- crucible_alloc (llvm_array max_sig_len i8);
   out_sig_len_ptr <- crucible_alloc i64;
@@ -163,7 +166,7 @@ let EVP_DigestVerifyFinal_spec = do {
 
   pctx_ops_ptr <- pointer_to_evp_md_pctx_ops;
 
-  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr;
+  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr (crucible_global SHA_UPDATE);
 
   sig_ptr <- crucible_alloc_readonly (llvm_array sig_len i8);
   (r, s) <- points_to_fresh_asn1_sig sig_ptr;
@@ -202,7 +205,7 @@ let EVP_DigestSign_spec = do {
 
   pctx_ops_ptr <- pointer_to_evp_md_pctx_ops;
 
-  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr;
+  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr (crucible_global SHA_UPDATE);
 
   out_sig_ptr <- crucible_alloc (llvm_array max_sig_len i8);
   out_sig_len_ptr <- crucible_alloc i64;
@@ -253,7 +256,7 @@ let EVP_DigestVerify_spec = do {
 
   pctx_ops_ptr <- pointer_to_evp_md_pctx_ops;
 
-  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr;
+  points_to_env_md_ctx_st_with_pctx ctx_ptr digest_ptr sha512_state_ptr evp_pkey_ctx_ptr pctx_ops_ptr (crucible_global SHA_UPDATE);
 
   len <- crucible_fresh_var "len" i64;
   (data, data_ptr) <- ptr_to_fresh_array_readonly "data" len;

--- a/SAW/proof/EVP/EVP_CTX.saw
+++ b/SAW/proof/EVP/EVP_CTX.saw
@@ -12,6 +12,8 @@ let NID_X9_62_id_ecPublicKey = 408;
 let EVP_PKEY_EC = NID_X9_62_id_ecPublicKey;
 let NID_HKDF = 969;
 let EVP_PKEY_HKDF = NID_HKDF;
+let NID_HMAC = 855;
+let EVP_PKEY_HMAC = NID_HMAC;
 
 let points_to_evp_pkey_method_st
       ptr
@@ -152,6 +154,27 @@ let points_to_EVP_PKEY_hkdf_pkey_meth ptr = points_to_evp_pkey_method_st
       (crucible_global "pkey_hkdf_ctrl") // ctrl
 ;
 
+let points_to_EVP_PKEY_hmac_pkey_meth ptr = points_to_evp_pkey_method_st
+      ptr
+      EVP_PKEY_HMAC // pkey_id
+      (crucible_global "hmac_init") // init
+      (crucible_global "hmac_copy") // copy
+      (crucible_global "hmac_cleanup") // cleanup
+      crucible_null // keygen
+      crucible_null // sign_init
+      crucible_null // sign
+      crucible_null // sign_message
+      crucible_null // verify_init
+      crucible_null // verify
+      crucible_null // verify_message
+      crucible_null // verify_recover
+      crucible_null // encrypt
+      crucible_null // decrypt
+      crucible_null // derive
+      crucible_null // paramgen
+      (crucible_global "hmac_ctrl") // ctrl
+;
+
 
 // Specification of `EVP_PKEY_rsa_pkey_meth_init`, the initialization
 // function for `EVP_PKEY_rsa_pkey_meth_storage`.
@@ -207,18 +230,35 @@ let EVP_PKEY_ec_pkey_meth_spec = do {
 // Specification of `EVP_PKEY_hkdf_pkey_meth_init`, the initialization function
 // for `EVP_PKEY_hkdf_pkey_meth_storage`.
 let EVP_PKEY_hkdf_pkey_meth_init_spec = do {
-crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
-crucible_execute_func [];
-points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+  crucible_execute_func [];
+  points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
 };
 let EVP_PKEY_hkdf_pkey_meth_spec = do {
-crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
-crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
-crucible_execute_func
-[ (crucible_global "EVP_PKEY_hkdf_pkey_meth_once")
-, (crucible_global "EVP_PKEY_hkdf_pkey_meth_init")
-];
-points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hkdf_pkey_meth_once";
+  crucible_execute_func
+  [ (crucible_global "EVP_PKEY_hkdf_pkey_meth_once")
+  , (crucible_global "EVP_PKEY_hkdf_pkey_meth_init")
+  ];
+  points_to_EVP_PKEY_hkdf_pkey_meth (crucible_global "EVP_PKEY_hkdf_pkey_meth_storage");
+};
+
+// Specification of `EVP_PKEY_hmac_pkey_meth_init`, the initialization function
+// for `EVP_PKEY_hmac_pkey_meth_storage`.
+let EVP_PKEY_hmac_pkey_meth_init_spec = do {
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_storage";
+  crucible_execute_func [];
+  points_to_EVP_PKEY_hmac_pkey_meth (crucible_global "EVP_PKEY_hmac_pkey_meth_storage");
+};
+let EVP_PKEY_hmac_pkey_meth_spec = do {
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_storage";
+  crucible_alloc_global "EVP_PKEY_hmac_pkey_meth_once";
+  crucible_execute_func
+  [ (crucible_global "EVP_PKEY_hmac_pkey_meth_once")
+  , (crucible_global "EVP_PKEY_hmac_pkey_meth_init")
+  ];
+  points_to_EVP_PKEY_hmac_pkey_meth (crucible_global "EVP_PKEY_hmac_pkey_meth_storage");
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -244,6 +284,12 @@ EVP_PKEY_ec_pkey_meth_ov <- llvm_unsafe_assume_spec
 
 llvm_verify m "EVP_PKEY_hkdf_pkey_meth_init" [] true EVP_PKEY_hkdf_pkey_meth_init_spec (w4_unint_z3 []);
 EVP_PKEY_hkdf_pkey_meth_ov <- llvm_unsafe_assume_spec
-m
-"CRYPTO_once"
-EVP_PKEY_hkdf_pkey_meth_spec;
+  m
+  "CRYPTO_once"
+  EVP_PKEY_hkdf_pkey_meth_spec;
+
+llvm_verify m "EVP_PKEY_hmac_pkey_meth_init" [] true EVP_PKEY_hmac_pkey_meth_init_spec (w4_unint_z3 []);
+EVP_PKEY_hmac_pkey_meth_ov <- llvm_unsafe_assume_spec
+  m
+  "CRYPTO_once"
+  EVP_PKEY_hmac_pkey_meth_spec;

--- a/SAW/proof/SHA512/SHA512-common-specs.saw
+++ b/SAW/proof/SHA512/SHA512-common-specs.saw
@@ -311,13 +311,21 @@ let points_to_env_md_st ptr = do {
 };
 
 // Specify the env_md_ctx_st struct
-let points_to_env_md_ctx_st ptr digest_ptr md_data_ptr = do {
+let points_to_env_md_ctx_st ptr digest_ptr md_data_ptr update_ptr = do {
   crucible_points_to (crucible_field ptr "digest") digest_ptr;
   crucible_points_to (crucible_field ptr "md_data") md_data_ptr;
-
   // Specify that the `pctx` and `pctx_ops` fields are null
   crucible_points_to (crucible_field ptr "pctx") crucible_null;
   crucible_points_to (crucible_field ptr "pctx_ops") crucible_null;
+  crucible_points_to (crucible_field ptr "update") update_ptr;
+  // Set flags to zero. This means that the following two flags are not set:
+  // 1. Flag |EVP_MD_CTX_FLAG_KEEP_PKEY_CTX|, so as to let |*pctx| refrain
+  //    from being freed when |*pctx| was set externally with
+  //    |EVP_MD_CTX_set_pkey_ctx|.
+  // 2. Flag |EVP_MD_CTX_HMAC| for |EVP_PKEY_HMAC|.
+  // We don't need these two flags because we are not verifying |EVP_MD_CTX_set_pkey_ctx|
+  // nor |EVP_PKEY_HMAC|
+  crucible_points_to (crucible_field ptr "flags") (crucible_term {{ 0 : [64] }});
 };
 
 let points_to_evp_md_pctx_ops ptr = do {
@@ -334,11 +342,20 @@ let pointer_to_evp_md_pctx_ops = do {
 };
 
 // Specify the env_md_ctx_st struct with non-null pctx and pctx_ops
-let points_to_env_md_ctx_st_with_pctx ptr digest_ptr md_data_ptr pctx_ptr pctx_ops_ptr = do {
+let points_to_env_md_ctx_st_with_pctx ptr digest_ptr md_data_ptr pctx_ptr pctx_ops_ptr update_ptr = do {
   crucible_points_to (crucible_field ptr "digest") digest_ptr;
   crucible_points_to (crucible_field ptr "md_data") md_data_ptr;
   crucible_points_to (crucible_field ptr "pctx") pctx_ptr;
   crucible_points_to (crucible_field ptr "pctx_ops") pctx_ops_ptr;
+  crucible_points_to (crucible_field ptr "update") update_ptr;
+  // Set flags to zero. This means that the following two flags are not set:
+  // 1. Flag |EVP_MD_CTX_FLAG_KEEP_PKEY_CTX|, so as to let |*pctx| refrain
+  //    from being freed when |*pctx| was set externally with
+  //    |EVP_MD_CTX_set_pkey_ctx|.
+  // 2. Flag |EVP_MD_CTX_HMAC| for |EVP_PKEY_HMAC|.
+  // We don't need these two flags because we are not verifying |EVP_MD_CTX_set_pkey_ctx|
+  // nor |EVP_PKEY_HMAC|
+  crucible_points_to (crucible_field ptr "flags") (crucible_term {{ 0 : [64] }});
   //crucible_points_to (crucible_field ptr "pctx_ops") (crucible_global "md_pctx_ops");
 };
 

--- a/SAW/proof/SHA512/evp-function-specs.saw
+++ b/SAW/proof/SHA512/evp-function-specs.saw
@@ -71,7 +71,7 @@ let EVP_DigestInit_array_spec = do {
   sha512_ctx_ptr <- llvm_alloc_sym_init (llvm_struct "struct.sha512_state_st");
   block' <- crucible_fresh_cryptol_var "block'" {| ByteArray |};
   points_to_sha512_state_st_array sha512_ctx_ptr {{ { h = SHAInit_Array.h, block = block', n = SHAInit_Array.n, sz = SHAInit_Array.sz } }};
-  points_to_env_md_ctx_st ctx_ptr type_ptr sha512_ctx_ptr;
+  points_to_env_md_ctx_st ctx_ptr type_ptr sha512_ctx_ptr (crucible_global SHA_UPDATE);
 
   // Postcondition: The function returns 1
   crucible_return (crucible_term {{ 1 : [32] }});
@@ -97,7 +97,7 @@ let EVP_DigestUpdate_array_spec = do {
 
   // Precondition: Struct pointed to by `ctx_ptr` points to `digest_ptr` and
   // `sha512_ctx_ptr`.
-  points_to_env_md_ctx_st ctx_ptr digest_ptr sha512_ctx_ptr;
+  points_to_env_md_ctx_st ctx_ptr digest_ptr sha512_ctx_ptr (crucible_global SHA_UPDATE);
 
   // Precondition: `data` is a fresh array of `len` bytes, and `data_ptr`
   // points to `data`.
@@ -120,7 +120,7 @@ let EVP_DigestUpdate_array_spec = do {
 
   // Postcondition: Struct pointed to by `ctx_ptr` points to `digest_ptr` and
   // `sha512_ctx_ptr`.
-  points_to_env_md_ctx_st ctx_ptr digest_ptr sha512_ctx_ptr;
+  points_to_env_md_ctx_st ctx_ptr digest_ptr sha512_ctx_ptr (crucible_global SHA_UPDATE);
 
   // Postcondition: The function returns 1
   crucible_return (crucible_term {{ 1 : [32] }});
@@ -153,7 +153,7 @@ let EVP_DigestFinalCommon_array_spec is_ex withLength = do {
 
   // Precondition: Struct pointed to by `ctx_ptr` points to `digest_ptr` and
   // `sha512_ctx_ptr`.
-  points_to_env_md_ctx_st ctx_ptr digest_ptr sha512_ctx_ptr;
+  points_to_env_md_ctx_st ctx_ptr digest_ptr sha512_ctx_ptr (crucible_global SHA_UPDATE);
 
   // Call function with `ctx_ptr`, `md_out_ptr`, and `s_ptr`
   crucible_execute_func [ctx_ptr, md_out_ptr, s_ptr];


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

AWS-LC PR: https://github.com/aws/aws-lc/pull/1324
Ticket: P109979459

1. Added `points_to_EVP_PKEY_hmac_pkey_meth`
2. Updated specifications and proofs to include globals related to `EVP_PKEY_HMAC`
3. Added precondition/postcondition about `update` and `flags` field of struct `env_md_ctx_st`
    1. For SHA2 and ECDSA, `update` will be initialized to `SHA_UPDATE` (either `sha384_update` or `sha512_update`)
    2. The `flags` field is always unset

