### PR TITLE
Add unbounded AES-GCM verification.

### DIFF
--- a/SAW/proof/AES/AES-CTR32.saw
+++ b/SAW/proof/AES/AES-CTR32.saw
@@ -1,0 +1,168 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+// Using experimental proof command "crucible_llvm_verify_x86"
+enable_experimental;
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Specifications
+
+let aes_hw_ctr32_encrypt_blocks_spec len = do {
+  let len' = eval_size {| len * AES_BLOCK_SIZE |};
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+
+  (in_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array len' (llvm_int 8));
+  out_ptr <- crucible_alloc (llvm_array len' (llvm_int 8));
+  key_ptr <- crucible_alloc_readonly (llvm_struct "struct.aes_key_st");
+  key <- fresh_aes_key_st;
+  points_to_aes_key_st key_ptr key;
+  (ivec, ivec_ptr) <- ptr_to_fresh_readonly "ivec" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+
+  crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `len : [64] }}), key_ptr, ivec_ptr];
+
+  crucible_points_to out_ptr (crucible_term {{ aes_hw_ctr32_encrypt_blocks in_ key ivec }});
+
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+};
+
+let aes_hw_ctr32_encrypt_blocks_spec' blocks = do {
+  let len' = eval_size {| blocks * AES_BLOCK_SIZE |};
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+
+  (in_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array len' (llvm_int 8));
+  out_ptr <- crucible_alloc (llvm_array len' (llvm_int 8));
+  key_ptr <- crucible_alloc_readonly (llvm_struct "struct.aes_key_st");
+  key <- fresh_aes_key_st;
+  points_to_aes_key_st key_ptr key;
+  (ivec, ivec_ptr) <- ptr_to_fresh_readonly "ivec" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+
+  crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `blocks : [64] }}), key_ptr, ivec_ptr];
+
+  crucible_points_to out_ptr (crucible_term {{ split`{each=8} (join (aes_ctr32_encrypt_blocks (join key) (join (take ivec)) (join (drop ivec)) (split (join in_)))) }});
+
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+};
+
+let aes_hw_ctr32_encrypt_blocks_array_spec blocks = do {
+  let len = eval_size {| blocks * AES_BLOCK_SIZE |};
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+
+  (in_, in_ptr) <- ptr_to_fresh_array_readonly "in" {{ `len : [64] }};
+  (out, out_ptr) <- ptr_to_fresh_array "out" {{ `len : [64] }};
+  key_ptr <- crucible_alloc_readonly (llvm_struct "struct.aes_key_st");
+  key <- fresh_aes_key_st;
+  points_to_aes_key_st key_ptr key;
+  (ivec, ivec_ptr) <- ptr_to_fresh_readonly "ivec" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+
+  crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `blocks : [64] }}), key_ptr, ivec_ptr];
+
+  crucible_points_to_array_prefix
+    out_ptr
+    {{ aes_ctr32_encrypt_blocks_array (join key) (join (take ivec)) (join (drop ivec)) in_ `blocks 0 out }}
+    {{ `len : [64] }};
+
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+};
+
+let aes_hw_ctr32_encrypt_bounded_array_spec = do {
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+
+  blocks <- llvm_fresh_var "blocks" (llvm_int 64);
+  let len = {{ blocks * `AES_BLOCK_SIZE }};
+  crucible_precond {{ 0 < blocks }};
+  crucible_precond {{ blocks < `MIN_BULK_BLOCKS }};
+
+  (in_, in_ptr) <- ptr_to_fresh_array_readonly "in" len;
+  (out, out_ptr) <- ptr_to_fresh_array "out" len;
+
+  key_ptr <- crucible_alloc_readonly (llvm_struct "struct.aes_key_st");
+  key <- fresh_aes_key_st;
+  points_to_aes_key_st key_ptr key;
+  (ivec, ivec_ptr) <- ptr_to_fresh_readonly "ivec" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+
+  crucible_execute_func [in_ptr, out_ptr, crucible_term blocks, key_ptr, ivec_ptr];
+
+  crucible_points_to_array_prefix
+    out_ptr
+    {{ aes_ctr32_encrypt_blocks_array (join key) (join (take ivec)) (join (drop ivec)) in_ blocks 0 out }}
+    len;
+
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Proof commands
+/*
+When verifying aes_hw_ctr32_encrypt_blocks, the binary analysis must locally
+treat r11 as callee-preserved. This is necessary because this routine saves
+the original stack pointer in r11 and then calls helper routines, preventing
+the binary analysis from inferring that the return address is still on the stack
+when the routine returns. The called helper routines do not modify r11.
+*/
+
+let aes_hw_ctr32_tactic = do {
+  simplify (cryptol_ss ());
+  simplify (addsimps slice_384_thms basic_ss);
+  goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
+  simplify (addsimps add_xor_slice_thms basic_ss);
+  simplify (addsimps aesenclast_thms basic_ss);
+  w4_unint_yices ["AESRound", "AESFinalRound"];
+};
+
+add_x86_preserved_reg "r11";
+aes_hw_ctr32_encrypt_blocks_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
+  []
+  true
+  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_encrypt)
+  aes_hw_ctr32_tactic;
+
+aes_hw_ctr32_encrypt_blocks_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
+  []
+  true
+  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_decrypt)
+  aes_hw_ctr32_tactic;
+default_x86_preserved_reg;
+
+aes_hw_ctr32_copy_thms <- for (eval_list {{ [ 1:[16] .. < MIN_BULK_BLOCKS ] }}) (\i -> do {
+  let blocks = eval_int i;
+  print (str_concat "aes_hw_ctr32 copy lemma: " (show blocks));
+  prove_theorem
+    (do {
+      w4_unint_z3 ["aes_ctr32_encrypt_block"];
+    })
+    (rewrite (cryptol_ss ()) {{ \key iv ctr in out ->
+      arrayEq
+        (arrayCopy out 0 (aes_ctr32_encrypt_blocks_array key iv ctr in `blocks 0 out) 0 `(16*blocks))
+        (aes_ctr32_encrypt_blocks_array key iv ctr in `blocks 0 out)
+    }});
+});
+
+aes_hw_ctr32_encrypt_blocks_concrete_ovs <- for (eval_list {{ [ 1:[16] .. < MIN_BULK_BLOCKS ] }}) (\i -> do {
+  let blocks = eval_int i;
+  print (str_concat "aes_hw_ctr32_encrypt blocks=" (show blocks));
+  add_x86_preserved_reg "r11";
+  ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test"
+    "aes_hw_ctr32_encrypt_blocks"
+    []
+    true
+    (aes_hw_ctr32_encrypt_blocks_spec' blocks)
+    aes_hw_ctr32_tactic;
+  default_x86_preserved_reg;
+  llvm_refine_spec' m "aes_hw_ctr32_encrypt_blocks"
+    [ov]
+    (aes_hw_ctr32_encrypt_blocks_array_spec blocks)
+    (w4_unint_z3 ["aes_ctr32_encrypt_block"]);
+});
+
+aes_hw_ctr32_encrypt_blocks_bounded_array_ov <- llvm_refine_spec' m "aes_hw_ctr32_encrypt_blocks"
+  aes_hw_ctr32_encrypt_blocks_concrete_ovs
+  aes_hw_ctr32_encrypt_bounded_array_spec
+  (do {
+    simplify (addsimps aes_hw_ctr32_copy_thms (cryptol_ss ()));
+    w4_unint_z3 ["aes_ctr32_encrypt_blocks_array"];
+  });
+

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -7,6 +7,8 @@ import "../../../cryptol-specs/Primitive/Symmetric/Cipher/Block/AES.cry";
 import "../../../cryptol-specs/Primitive/Symmetric/Cipher/Authenticated/AES_256_GCM.cry";
 import "../../spec/AES/X86.cry";
 import "../../spec/AES/AES-GCM.cry";
+import "../../spec/AES/AES-GCM-implementation.cry";
+import "../../spec/AES/AES-GCM-unbounded.cry";
 
 
 enable_experimental;
@@ -93,6 +95,21 @@ let aes_block_size = 1;
 // the IV for AES-GCM consists of 12 32-bit integers
 let aes_iv_len = 12;
 
+// This computes the total number of message blocks that can be
+// handeled by a single AES/GCM mode session. The GCM counter is
+// a 32-bit counter which starts at 1, and we need to leave a block at
+// the end for the authentication tag. This gives us a total of
+// slightly fewer than 2^^32 blocks we can handle.
+let TOTAL_MESSAGE_BLOCKS = eval_size {| 2^^32 - 2 |};
+
+// This is the minimum number of blocks that can be processed by the bulk
+// encrypt/decrypt phase.  This is due to the fact that the bulk encryption
+// phase processes 6 block chunks, and has a pipeline setup which is three
+// stages deep. Thus, 18 blocks is the minimum number of blocks it will
+// process; fewer than that and it will simply rely on the separate AES/CTR32
+// and GHASH routines.
+let MIN_BULK_BLOCKS = 18;
+
 
 /*
  * Architecture features for the AVX+shrd code path
@@ -104,39 +121,8 @@ let {{ ia32cap = [0xffffffff, 0xffffffff, 0x3ffcffff, 0xffffffff] : [4][32] }};
 
 include "AES.saw";
 include "GHASH.saw";
+include "AES-CTR32.saw";
 include "AESNI-GCM.saw";
-
-/*
-When verifying aes_hw_ctr32_encrypt_blocks, the binary analysis must locally
-treat r11 as callee-preserved. This is necessary because this routine saves
-the original stack pointer in r11 and then calls helper routines, preventing
-the binary analysis from inferring that the return address is still on the stack
-when the routine returns. The called helper routines do not modify r11.
-*/
-
-let aes_hw_ctr32_tactic = do {
-  simplify (cryptol_ss ());
-  simplify (addsimps slice_384_thms basic_ss);
-  simplify (addsimps [cmp_sub_thm] empty_ss);
-  goal_eval_unint ["AESRound", "AESFinalRound", "aesenc", "aesenclast"];
-  simplify (addsimps add_xor_slice_thms basic_ss);
-  simplify (addsimps aesenclast_thms basic_ss);
-  w4_unint_yices ["AESRound", "AESFinalRound"];
-};
-
-add_x86_preserved_reg "r11";
-aes_hw_ctr32_encrypt_blocks_encrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
-  []
-  true
-  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_encrypt)
-  aes_hw_ctr32_tactic;
-
-aes_hw_ctr32_encrypt_blocks_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "aes_hw_ctr32_encrypt_blocks"
-  []
-  true
-  (aes_hw_ctr32_encrypt_blocks_spec whole_blocks_after_bulk_decrypt)
-  aes_hw_ctr32_tactic;
-default_x86_preserved_reg;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -157,6 +143,10 @@ let EVP_CIPH_CTRL_INIT = 0x200;
 let EVP_CIPH_FLAG_CUSTOM_CIPHER = 0x400;
 let EVP_CIPH_FLAG_AEAD_CIPHER = 0x800;
 let EVP_CIPH_CUSTOM_COPY = 0x1000;
+
+// This is the total number of bytes that can be in the plain/cyphertext
+// for AES-GCM.
+let TOTAL_MESSAGE_MAX_LENGTH = eval_size {| TOTAL_MESSAGE_BLOCKS * AES_BLOCK_SIZE |};
 
 let points_to_evp_cipher_st ptr = do {
   crucible_points_to (crucible_elem ptr 0) (crucible_term {{ `NID_aes_256_gcm : [32] }});
@@ -193,13 +183,21 @@ let fresh_aes_gcm_ctx len = do {
   return {{ { key = key, iv = iv, Xi = Xi, len = `len } : AES_GCM_Ctx }};
 };
 
+let fresh_aes_gcm_ctx' mres = do {
+  key <- fresh_aes_key_st;
+  iv <- crucible_fresh_var "iv" (llvm_array aes_iv_len (llvm_int 8));
+  Xi <- crucible_fresh_var "Xi" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+  len_60 <- llvm_fresh_var "ctx.len" (llvm_int 60);
+  let len = {{ (len_60 # `mres): [64] }};
+  return {{ { key = key, iv = iv, Xi = Xi, len = len } : AES_GCM_Ctx }};
+};
+
 let points_to_gcm128_key_st ptr ctx = do {
-  crucible_points_to_untyped (crucible_elem ptr 1) (crucible_term {{ get_Htable ctx }});
-  crucible_points_to_untyped (crucible_elem ptr 0) (crucible_term {{ get_H ctx }});
-  crucible_points_to (crucible_elem ptr 2) (crucible_global "gcm_gmult_avx");
-  crucible_points_to (crucible_elem ptr 3) (crucible_global "gcm_ghash_avx");
-  crucible_points_to (crucible_elem ptr 4) (crucible_global "aes_hw_encrypt");
-  crucible_points_to (crucible_elem ptr 5) (crucible_term {{ 1 : [8] }});
+  crucible_points_to_untyped (crucible_elem ptr 0) (crucible_term {{ get_Htable ctx.key }});
+  crucible_points_to (crucible_elem ptr 1) (crucible_global "gcm_gmult_avx");
+  crucible_points_to (crucible_elem ptr 2) (crucible_global "gcm_ghash_avx");
+  crucible_points_to (crucible_elem ptr 3) (crucible_global "aes_hw_encrypt");
+  crucible_points_to (crucible_elem ptr 4) (crucible_term {{ 1 : [8] }});
 };
 
 let points_to_GCM128_CONTEXT ptr ctx mres = do {
@@ -297,6 +295,77 @@ llvm_verify m "EVP_DecryptUpdate"
   (EVP_CipherUpdate_spec {{ 0 : [32] }} evp_cipher_update_gcm_len evp_cipher_update_len)
   evp_cipher_tactic;
 
+enable_what4_eval;
+
+llvm_verify m "EVP_EncryptUpdate"
+  [ aes_gcm_from_cipher_ctx_ov
+  , aes_hw_encrypt_ov
+  , aes_hw_ctr32_encrypt_blocks_bounded_array_ov
+  , gcm_gmult_avx_ov
+  , gcm_ghash_avx_bounded_array_ov
+  , aesni_gcm_encrypt_array_ov
+  , aesni_gcm_decrypt_array_ov
+  ]
+  true
+  (EVP_CipherUpdate_array_spec {{ 1 : [32] }} 1 15)
+  (do {
+    simplify (cryptol_ss ());
+    goal_eval_unint ["aesni_gcm_encrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod"];
+    simplify (addsimps [aesni_gcm_encrypt_Yi_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod"];
+    simplify (addsimps [bvand_bvudiv_thm, bvudiv_bvmul_bvudiv_thm, bvurem_16_append_thm] basic_ss);
+    simplify (addsimps [arrayLookupUnint_thm, arrayUpdateUnint_thm, arrayCopyUnint_thm, arrayConstantUnint_thm] empty_ss);
+    simplify (addsimps add_xor_slice_thms basic_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    simplify (addsimps [ite_bveq_0_thm, ite_bveq_1_thm, bveq_ite_bv8_0_thm, bveq_ite_bv8_1_thm, arrayeq_ite_0_thm, arrayeq_ite_1_thm, foo_thm, bar_thm] basic_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    print_goal;
+    is_out_post <- goal_has_some_tag ["output buffer postcondition"];
+    is_Xi_post <- goal_has_some_tag ["Xi postcondition"];
+    if is_out_post then do {
+      w4_unint_yices ["aesni_gcm_encrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    } else if is_Xi_post then do {
+      w4_unint_z3_using "qfufbv" ["aesni_gcm_encrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    } else do {
+      w4_unint_z3 ["aesni_gcm_encrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    };
+  });
+
+llvm_verify m "EVP_DecryptUpdate"
+  [ aes_gcm_from_cipher_ctx_ov
+  , aes_hw_encrypt_ov
+  , aes_hw_ctr32_encrypt_blocks_bounded_array_ov
+  , gcm_gmult_avx_ov
+  , gcm_ghash_avx_bounded_array_ov
+  , aesni_gcm_encrypt_array_ov
+  , aesni_gcm_decrypt_array_ov
+  ]
+  true
+  (EVP_CipherUpdate_array_spec {{ 0 : [32] }} 1 15)
+  (do {
+    simplify (cryptol_ss ());
+    goal_eval_unint ["aesni_gcm_decrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod"];
+    simplify (addsimps [aesni_gcm_decrypt_Yi_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_decrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod"];
+    simplify (addsimps [bvand_bvudiv_thm, bvudiv_bvmul_bvudiv_thm, bvurem_16_append_thm] basic_ss);
+    simplify (addsimps [arrayLookupUnint_thm, arrayUpdateUnint_thm, arrayCopyUnint_thm, arrayConstantUnint_thm] empty_ss);
+    simplify (addsimps add_xor_slice_thms basic_ss);
+    goal_eval_unint ["aesni_gcm_decrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    simplify (addsimps [ite_bveq_0_thm, ite_bveq_1_thm, bveq_ite_bv8_0_thm, bveq_ite_bv8_1_thm, arrayeq_ite_0_thm, arrayeq_ite_1_thm, foo_thm, bar_thm] basic_ss);
+    goal_eval_unint ["aesni_gcm_decrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    print_goal;
+    is_out_post <- goal_has_some_tag ["output buffer postcondition"];
+    is_Xi_post <- goal_has_some_tag ["Xi postcondition"];
+    if is_out_post then do {
+      w4_unint_yices ["aesni_gcm_decrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    } else if is_Xi_post then do {
+      w4_unint_z3_using "qfufbv" ["aesni_gcm_decrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    } else do {
+      w4_unint_z3 ["aesni_gcm_decrypt", "aes_ctr32_encrypt_blocks_array", "aes_hw_encrypt", "gcm_ghash_blocks_array", "gcm_polyval", "pmult", "pmod", "arrayLookupUnint", "arrayUpdateUnint", "arrayCopyUnint", "arrayConstantUnint"];
+    };
+  });
+
+disable_what4_eval;
 disable_what4_hash_consing;
 
 

--- a/SAW/proof/AES/AES.saw
+++ b/SAW/proof/AES/AES.saw
@@ -106,25 +106,6 @@ let aes_hw_decrypt_in_place_spec = do {
 };
 
 
-let aes_hw_ctr32_encrypt_blocks_spec len = do {
-  let len' = eval_size {| len * AES_BLOCK_SIZE |};
-  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
-
-  (in_, in_ptr) <- ptr_to_fresh_readonly "in" (llvm_array len' (llvm_int 8));
-  out_ptr <- crucible_alloc (llvm_array len' (llvm_int 8));
-  key_ptr <- crucible_alloc_readonly (llvm_struct "struct.aes_key_st");
-  key <- fresh_aes_key_st;
-  points_to_aes_key_st key_ptr key;
-  (ivec, ivec_ptr) <- ptr_to_fresh_readonly "ivec" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
-
-  crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `len : [64] }}), key_ptr, ivec_ptr];
-
-  crucible_points_to out_ptr (crucible_term {{ aes_hw_ctr32_encrypt_blocks in_ key ivec }});
-
-  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
-};
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Proof commands

--- a/SAW/proof/AES/AESNI-GCM.saw
+++ b/SAW/proof/AES/AESNI-GCM.saw
@@ -21,15 +21,13 @@ let aesni_gcm_cipher_spec enc gcm_len len = do {
   ivec <- crucible_fresh_var "ivec" (llvm_array aes_iv_len (llvm_int 8));
   crucible_points_to_untyped (crucible_elem ivec_ptr 0) (crucible_term ivec);
   crucible_points_to_untyped (crucible_elem ivec_ptr 12) (crucible_term {{ split`{4} (`ctr : [32]) }});
-  Xi_ptr <- crucible_alloc (llvm_array 14 (llvm_int 128));
-  Xi <- crucible_fresh_var "Xi" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+  Htable_ptr <- crucible_alloc_readonly_aligned 16 (llvm_array 12 (llvm_int 128));
+  crucible_points_to Htable_ptr (crucible_term {{ get_Htable key }});
+  (Xi, Xi_ptr) <- ptr_to_fresh "Xi" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
   let ctx = {{ { key = key, iv = ivec, Xi = Xi, len = `gcm_len } : AES_GCM_Ctx }};
-  crucible_points_to_untyped (crucible_elem Xi_ptr 2) (crucible_term {{ get_Htable ctx }});
-  crucible_points_to_untyped (crucible_elem Xi_ptr 1) (crucible_term {{ get_H ctx }});
-  crucible_points_to_untyped (crucible_elem Xi_ptr 0) (crucible_term Xi);
   points_to_aes_key_st key_ptr key;
 
-  crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `len : [64] }}), key_ptr, ivec_ptr, Xi_ptr];
+  crucible_execute_func [in_ptr, out_ptr, (crucible_term {{ `len : [64] }}), key_ptr, ivec_ptr, Htable_ptr, Xi_ptr];
 
   let bulk_len = eval_size {| max min_size ((len / (6 * AES_BLOCK_SIZE)) * (6 * AES_BLOCK_SIZE)) |};
   let do_bulk = eval_size {| len / bulk_len |};
@@ -37,8 +35,6 @@ let aesni_gcm_cipher_spec enc gcm_len len = do {
   let res_ctr = eval_size {| ctr + res_len / AES_BLOCK_SIZE |};
 
   crucible_points_to ivec_ptr (crucible_term {{ ivec # (split (`res_ctr : [32])) }});
-  crucible_points_to_untyped (crucible_elem Xi_ptr 2) (crucible_term {{ get_Htable ctx }});
-  crucible_points_to_untyped (crucible_elem Xi_ptr 1) (crucible_term {{ get_H ctx }});
 
   if eval_bool {{ `do_bulk == 0 }} then do {
     crucible_points_to_untyped (crucible_elem Xi_ptr 0) (crucible_term Xi);
@@ -48,6 +44,44 @@ let aesni_gcm_cipher_spec enc gcm_len len = do {
   };
 
   crucible_return (crucible_term {{ `res_len : [64] }});
+};
+
+let aesni_gcm_cipher_array_spec enc = do {
+  len <- llvm_fresh_var "len" (llvm_int 64);
+  crucible_precond {{ len < 2 ^^ 36 }};
+
+  (in_, in_ptr) <- ptr_to_fresh_array_readonly "in" len;
+  (out, out_ptr) <- ptr_to_fresh_array "out" len;
+
+  key <- fresh_aes_key_st;
+  key_ptr <- crucible_alloc_readonly (llvm_struct "struct.aes_key_st");
+  points_to_aes_key_st key_ptr key;
+  ivec_ptr <- crucible_alloc (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+  ivec <- crucible_fresh_var "ivec" (llvm_array aes_iv_len (llvm_int 8));
+  ctr <- crucible_fresh_var "ctr" (llvm_array 4 (llvm_int 8));
+  crucible_points_to_untyped (crucible_elem ivec_ptr 0) (crucible_term ivec);
+  crucible_points_to_untyped (crucible_elem ivec_ptr 12) (crucible_term ctr);
+  Htable_ptr <- crucible_alloc_readonly_aligned 16 (llvm_array 12 (llvm_int 128));
+  crucible_points_to Htable_ptr (crucible_term {{ get_Htable key }});
+  (Xi, Xi_ptr) <- ptr_to_fresh "Xi" (llvm_array AES_BLOCK_SIZE (llvm_int 8));
+
+  crucible_execute_func [in_ptr, out_ptr, (crucible_term len), key_ptr, ivec_ptr, Htable_ptr, Xi_ptr];
+
+  let res = if enc then {{
+    if 288 <= len then aesni_gcm_encrypt len in_ out key ivec ctr Xi 0 out (join Xi) else (out, join Xi, join (ivec # ctr))
+  }} else {{
+    if 96 <= len then aesni_gcm_decrypt len in_ out key ivec ctr Xi 0 out (join Xi) else (out, join Xi, join (ivec # ctr))
+  }};
+
+  llvm_points_to_array_prefix out_ptr {{ res.0 }} len;
+  crucible_points_to Xi_ptr (crucible_term {{ split`{each=8} res.1 }});
+  crucible_points_to ivec_ptr (crucible_term {{ split`{each=8} res.2 }});
+
+  if enc then do {
+    llvm_return (llvm_term {{ if 288 <= len then 96 * (len / 96) else 0 }});
+  } else do {
+    llvm_return (llvm_term {{ if 96 <= len then 96 * (len / 96) else 0 }});
+  };
 };
 
 
@@ -74,5 +108,90 @@ aesni_gcm_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "
   (aesni_gcm_cipher_spec {{ 0 : [32] }} aesni_gcm_cipher_gcm_len aesni_gcm_cipher_len)
   aesni_gcm_cipher_tactic;
 
+enable_what4_eval;
+enable_x86_what4_hash_consing;
+
+aesni_gcm_encrypt_array_ov <- llvm_verify_fixpoint_x86' m "../../build/x86/crypto/crypto_test" "aesni_gcm_encrypt"
+  [ ("byte64_len_to_mask_table", 704) // We need .Lbswap_mask. Its location is <byte64_len_to_mask_table+0x240>. 704 bytes is an offset that would be large enough to contain the right bytes after alignment.
+  ]
+  true
+  {{ aesni_gcm_encrypt_impl_loop }}
+  (aesni_gcm_cipher_array_spec true)
+  (do {
+    simplify (addsimp_shallow aesni_gcm_encrypt_impl_loop_thm empty_ss);
+    simplify (addsimps [aesenc_key0_0_thm, aesenc_key0_1_thm, aesenclast_thm] empty_ss);
+    simplify (addsimps [aesenc_aesenclast_thm, aesenc_aesenclast_1_thm] empty_ss);
+    simplify (addsimps [aesEncryptWithKeySchedule_swap8_0_thm, aesEncryptWithKeySchedule_swap8_1_thm] empty_ss);
+    simplify (addsimps [arrayRangeLookup_impl64_0_thm, arrayRangeLookup_impl64_8_thm, arrayRangeLookup_impl64_16_thm, arrayRangeLookup_impl64_24_thm, arrayRangeLookup_impl64_32_thm, arrayRangeLookup_impl64_40_thm, arrayRangeLookup_impl64_48_thm, arrayRangeLookup_impl64_56_thm, arrayRangeLookup_impl64_64_thm, arrayRangeLookup_impl64_72_thm, arrayRangeLookup_impl64_80_thm, arrayRangeLookup_impl64_88_thm] empty_ss);
+    simplify (cryptol_ss ());
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "gcm_polyval_red_half_pmult", "loadHalfBlock"];
+    simplify (cryptol_ss ());
+    simplify (addsimps concat_assoc_0_thms empty_ss);
+    simplify (addsimps concat_assoc_1_thms empty_ss);
+    simplify (addsimps concat_assoc_2_thms empty_ss);
+    simplify (addsimps [foo_append_slice_thm, bar_append_slice_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "gcm_polyval_red_half_pmult", "loadHalfBlock"];
+    simplify (addsimps [slt_0_thm, slt_1_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    simplify (addsimps [aesEncryptWithKeySchedule_ExpandKey_thm] empty_ss);
+    simplify (addsimps slice_slice_thms empty_ss);
+    simplify (addsimps xor_slice_append_thms basic_ss);
+    simplify (addsimps concat_assoc_0_thms empty_ss);
+    simplify (addsimps concat_assoc_1_thms empty_ss);
+    simplify (addsimps concat_assoc_2_thms empty_ss);
+    simplify (addsimps [ite_slt_1_thm, ite_slt_2_thm, ite_slt_3_thm, ite_slt_4_thm, ite_slt_5_thm, ite_slt_6_thm, ite_slt_7_thm, ite_slt_8_thm, ite_slt_9_thm, ite_slt_10_thm, ite_slt_11_thm, ite_slt_12_thm ] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    simplify (addsimps [ite_slt_1_thm, ite_slt_2_thm, ite_slt_3_thm, ite_slt_4_thm, ite_slt_5_thm, ite_slt_6_thm, ite_slt_7_thm, ite_slt_8_thm, ite_slt_9_thm, ite_slt_10_thm, ite_slt_11_thm, ite_slt_12_thm, ite_slt_12_thm'] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    simplify (addsimps [append_0_xor_thm, append_xor_0_thm, append_add_thm, append_slice_4_8_thm, append_assoc_1_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    simplify (addsimps [append_0_xor_thm, append_xor_0_thm, append_add_thm, append_slice_4_8_thm, append_assoc_1_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    simplify (addsimps [add_ite_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "get_Htable", "loadHalfBlock"];
+    goal_eval_unint ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "gcm_init_H", "loadHalfBlock"];
+
+    goal_num_ite 3 (do {
+      w4_unint_yices ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "gcm_init_H", "loadHalfBlock"];
+    }) (do {
+      w4_unint_z3 ["aesni_gcm_encrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_H'", "gcm_init_H", "loadHalfBlock"];
+    });
+  });
+
+aesni_gcm_decrypt_array_ov <- llvm_verify_fixpoint_x86' m "../../build/x86/crypto/crypto_test" "aesni_gcm_decrypt"
+  [ ("byte64_len_to_mask_table", 704) // We need .Lbswap_mask. Its location is <byte64_len_to_mask_table+0x240>. 704 bytes is an offset that would be large enough to contain the right bytes after alignment.
+  ]
+  true
+  {{ aesni_gcm_decrypt_impl_loop }}
+  (aesni_gcm_cipher_array_spec false)
+  (do {
+    simplify (addsimp_shallow aesni_gcm_decrypt_impl_loop_thm empty_ss);
+    simplify (addsimps [aesenc_key0_0_thm, aesenc_key0_1_thm, aesenclast_thm] empty_ss);
+    simplify (addsimps [aesenc_aesenclast_thm, aesenc_aesenclast_1_thm] empty_ss);
+    simplify (addsimps [aesEncryptWithKeySchedule_swap8_0_thm, aesEncryptWithKeySchedule_swap8_1_thm] empty_ss);
+    simplify (cryptol_ss ());
+    simplify (addsimps concat_assoc_0_thms empty_ss);
+    simplify (addsimps concat_assoc_1_thms empty_ss);
+    simplify (addsimps concat_assoc_2_thms empty_ss);
+    simplify (addsimps [foo_append_slice_thm, bar_append_slice_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_decrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_decrypt_impl_loop", "get_H'", "get_Htable"];
+    goal_eval_unint ["aesni_gcm_decrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_decrypt_impl_loop", "get_H'", "get_Htable"];
+    simplify (addsimps [aesEncryptWithKeySchedule_ExpandKey_thm] empty_ss);
+    simplify (addsimps xor_slice_append_thms basic_ss);
+    simplify (addsimps slice_slice_thms empty_ss);
+    simplify (addsimps xor_slice_append_thms basic_ss);
+    simplify (addsimps concat_assoc_0_thms empty_ss);
+    simplify (addsimps concat_assoc_1_thms empty_ss);
+    simplify (addsimps concat_assoc_2_thms empty_ss);
+    simplify (addsimps [append_0_xor_thm, append_xor_0_thm, append_add_thm] empty_ss);
+    goal_eval_unint ["aesni_gcm_decrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "aesni_gcm_decrypt_impl_loop", "get_H'", "get_Htable"];
+    w4_unint_yices ["aesni_gcm_decrypt", "pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_decrypt_impl_loop", "get_H'", "get_Htable"];
+  });
+
+disable_x86_what4_hash_consing;
+disable_what4_eval;
 disable_what4_hash_consing;
 default_x86_preserved_reg;
+

--- a/SAW/proof/AES/GHASH.saw
+++ b/SAW/proof/AES/GHASH.saw
@@ -42,6 +42,25 @@ let gcm_ghash_avx_spec len = do {
   crucible_points_to Xi_ptr (crucible_term {{ gcm_ghash Htable0 Xi inp }});
 };
 
+let gcm_ghash_avx_bounded_array_spec = do {
+  (Xi, Xi_ptr) <- ptr_to_fresh "Xi" (llvm_array 16 (llvm_int 8));
+  Htable_ptr <- crucible_alloc_readonly (llvm_array 12 (llvm_int 128));
+  Htable0 <- crucible_fresh_var "Htable0" (llvm_int 128);
+  crucible_points_to_untyped (crucible_elem Htable_ptr 1) (crucible_term {{ drop`{1} (gcm_init_Htable Htable0) }});
+  crucible_points_to_untyped (crucible_elem Htable_ptr 0) (crucible_term {{ Htable0 }});
+
+  len <- llvm_fresh_var "len" (llvm_int 64);
+  crucible_precond {{ len % `AES_BLOCK_SIZE == 0 }};
+  crucible_precond {{ 0 < len }};
+  crucible_precond {{ len < `AES_BLOCK_SIZE * `MIN_BULK_BLOCKS }};
+
+  (in_, in_ptr) <- ptr_to_fresh_array_readonly "in" len;
+
+  crucible_execute_func [Xi_ptr, Htable_ptr, in_ptr, crucible_term len];
+
+  crucible_points_to Xi_ptr (crucible_term {{ split`{each=8} (gcm_ghash_blocks_array Htable0 in_ (len / 16) 0 (join Xi)) }});
+};
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // Proof commands
@@ -105,5 +124,73 @@ gcm_ghash_avx_decrypt_ov <- llvm_verify_x86 m "../../build/x86/crypto/crypto_tes
   (gcm_ghash_avx_spec GHASH_length_blocks_decrypt)
   gcm_ghash_avx_tactic;
 
+enable_what4_eval;
+
+gcm_ghash_avx_concrete_ovs <- for (eval_list {{ [ 1:[16] .. < MIN_BULK_BLOCKS ] }}) (\i -> do {
+  let len = eval_int {{ i * 16 }};
+  print (str_concat "gcm_ghash_avx len=" (show len));
+
+  gcm_ghash_avx_thm <- prove_theorem
+    (do {
+      goal_eval_unint ["pmult", "pmod", "gcm_polyval", "gcm_polyval_mul", "gcm_polyval_mul_pmult3", "gcm_polyval_mul_pmult4", "gcm_polyval_red", "gcm_polyval_red_pmult"];
+      simplify (addsimps gcm_polyval_thms empty_ss);
+      simplify (addsimps [concat_assoc_0_thm] empty_ss);
+      w4_unint_yices ["pmult", "pmod", "gcm_polyval"];
+    })
+    (rewrite (cryptol_ss ()) {{ \H Xi (in : [len][8]) -> gcm_ghash H Xi in == gcm_ghash_avx`{n=((len/16)-1)/8} H Xi in }});
+
+  llvm_verify_x86 m "../../build/x86/crypto/crypto_test" "gcm_ghash_avx"
+    [ ("shufb_15_7", 384) ]
+    true
+    (gcm_ghash_avx_spec len)
+    (do {
+      simplify (cryptol_ss ());
+      simplify (addsimps [gcm_ghash_avx_thm] empty_ss);
+      goal_eval_unint ["pmult", "pmod", "gcm_polyval"];
+      simplify (addsimps xor_slice_append_thms basic_ss);
+      simplify (addsimps slice_slice_thms empty_ss);
+      simplify (addsimps xor_slice_append_thms basic_ss);
+      simplify (addsimps concat_assoc_0_thms empty_ss);
+      simplify (addsimps concat_assoc_1_thms empty_ss);
+      simplify (addsimps concat_assoc_2_thms empty_ss);
+      goal_eval_unint ["pmult", "pmod", "gcm_polyval"];
+      goal_eval_unint ["pmult", "pmod", "gcm_polyval"];
+      goal_eval_unint ["pmult", "pmod", "gcm_polyval"];
+      goal_eval_unint ["pmult", "pmod", "gcm_polyval"];
+      goal_eval_unint ["pmult", "pmod", "gcm_polyval"];
+      w4_unint_z3 ["pmult", "pmod", "gcm_polyval"];
+    });
+});
+
+// Assemble the individual proofs at each concrete length
+// into the overall specification
+gcm_ghash_avx_bounded_array_ov <- llvm_refine_spec' m "gcm_ghash_avx"
+  gcm_ghash_avx_concrete_ovs
+  gcm_ghash_avx_bounded_array_spec
+  (do {
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    unfolding_fix_once ["gcm_ghash_blocks_array"];
+    goal_eval_unint ["gcm_ghash_blocks_array", "gcm_polyval"];
+    w4_unint_z3 ["gcm_ghash_blocks_array", "gcm_polyval"];
+  });
+
+
+disable_what4_eval;
 disable_what4_hash_consing;
 

--- a/SAW/proof/AES/evp-function-specs.saw
+++ b/SAW/proof/AES/evp-function-specs.saw
@@ -74,6 +74,53 @@ let EVP_CipherUpdate_spec enc gcm_len len = do {
   crucible_return (crucible_term {{ 1 : [32] }});
 };
 
+let EVP_CipherUpdate_array_spec enc mres res_mres = do {
+  global_alloc_init "OPENSSL_ia32cap_P" {{ ia32cap }};
+
+  cipher_ptr <- crucible_alloc_readonly (llvm_struct "struct.evp_cipher_st");
+  points_to_evp_cipher_st cipher_ptr;
+
+  cipher_data_ptr <- crucible_alloc_aligned 16 (llvm_struct "struct.EVP_AES_GCM_CTX");
+  ctx <- fresh_aes_gcm_ctx' mres;
+  points_to_EVP_AES_GCM_CTX cipher_data_ptr ctx mres {{ 1 : [32] }} 0xffffffff;
+
+  ctx_ptr <- crucible_alloc (llvm_struct "struct.evp_cipher_ctx_st");
+  points_to_evp_cipher_ctx_st ctx_ptr cipher_ptr cipher_data_ptr enc;
+
+  len_28 <- llvm_fresh_var "len" (llvm_int 28);
+  let len = {{ (len_28 # (`res_mres - `mres)): [32] }};
+  crucible_precond {{ len < 2 ^^ 31 }};
+  crucible_precond {{ ctx.len < `TOTAL_MESSAGE_MAX_LENGTH }};
+  crucible_precond {{ ctx.len + (0 # len) < `TOTAL_MESSAGE_MAX_LENGTH }};
+
+  (in_, in_ptr) <- ptr_to_fresh_array_readonly "in" {{ sext len : [64] }};
+  (out, out_ptr) <- ptr_to_fresh_array "out" {{ sext len : [64] }};
+
+  out_len_ptr <- crucible_alloc (llvm_int 32);
+
+  crucible_execute_func [ctx_ptr, out_ptr, out_len_ptr, in_ptr, (crucible_term len)];
+
+  points_to_evp_cipher_ctx_st ctx_ptr cipher_ptr cipher_data_ptr enc;
+
+  let res = if eval_bool {{ enc == 1 }} then {{
+    aes_gcm_encrypt_update ctx in_ (sext len) out
+  }} else {{
+    aes_gcm_decrypt_update ctx in_ (sext len) out
+  }};
+
+  llvm_setup_with_tag "Xi postcondition" do {
+    points_to_EVP_AES_GCM_CTX cipher_data_ptr {{ res.0 }} res_mres {{ 1 : [32] }} 0xffffffff;
+  };
+
+  llvm_setup_with_tag "output buffer postcondition" do {
+    llvm_points_to_array_prefix out_ptr {{ res.1 }} {{ sext len : [64] }};
+  };
+
+  crucible_points_to out_len_ptr (crucible_term len);
+
+  crucible_return (crucible_term {{ 1 : [32] }});
+};
+
 let EVP_EncryptFinal_ex_spec gcm_len = do {
   cipher_ptr <- crucible_alloc_readonly (llvm_struct "struct.evp_cipher_st");
   points_to_evp_cipher_st cipher_ptr;

--- a/SAW/proof/AES/goal-rewrites-AES.saw
+++ b/SAW/proof/AES/goal-rewrites-AES.saw
@@ -132,12 +132,12 @@ let add_xor_slice_thms =
   , slice_xor_27_thm
   ];
 
-aesenclast_0_thm <- prove_print
+aesenclast_0_thm <- prove_theorem
   (do {
     w4_unint_yices ["ShiftRows", "SubBytes"];
   })
   (rewrite (cryptol_ss ()) {{ \(x : [8]) y z key -> aesenclast key ((x # y) ^ z) == (x # y) ^ (aesenclast key z) }});
-aesenclast_1_thm <- prove_print
+aesenclast_1_thm <- prove_theorem
   (do {
     w4_unint_yices ["ShiftRows", "SubBytes"];
   })

--- a/SAW/proof/AES/goal-rewrites.saw
+++ b/SAW/proof/AES/goal-rewrites.saw
@@ -10,7 +10,6 @@
  * verification result.
  */
 
-import "../../spec/AES/AES-GCM-implementation.cry";
 include "goal-rewrites-AES.saw";
 
 bar0 <- prove_folding_theorem {{ \(x : [128]) -> \y -> (x ^ y) ^ y == x }};
@@ -197,21 +196,21 @@ let concat_assoc_2_thms =
   ];
 
 
-gcm_pmult_pmod_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \x y -> gcm_pmult_pmod x y == gcm_polyval (gcm_init_H x) y }});
+gcm_pmult_pmod_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \x y -> gcm_pmult_pmod x y == gcm_polyval (gcm_init_H x) y }});
 
 
-polyval_avx_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \H Xi -> gcm_polyval H Xi == gcm_polyval_avx H Xi }});
-ghash_mul_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \(x : [128]) y -> gcm_polyval_mul x y == gcm_polyval_mul_pmult3 x y }});
-ghash_red_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \x -> gcm_polyval_red x == gcm_polyval_red_pmult x }});
+polyval_avx_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \H Xi -> gcm_polyval H Xi == gcm_polyval_avx H Xi }});
+ghash_mul_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \(x : [128]) y -> gcm_polyval_mul x y == gcm_polyval_mul_pmult3 x y }});
+ghash_red_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \x -> gcm_polyval_red x == gcm_polyval_red_pmult x }});
 
 
-gcm_polyval_mul_0_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \(x : [128]) (y : [128]) -> gcm_polyval_mul_pmult3 x y == gcm_polyval_mul x y }});
-gcm_polyval_mul_1_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \(x : [128]) (y : [128]) -> gcm_polyval_mul_pmult4 x y == gcm_polyval_mul x y }});
-gcm_polyval_red_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \x -> gcm_polyval_red_pmult x == gcm_polyval_red x }});
-gcm_polyval_red_xor_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \x y -> gcm_polyval_red (x ^ y) == (gcm_polyval_red x) ^ (gcm_polyval_red y) }});
-gcm_polyval_mul_red_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \x y -> gcm_polyval_red (gcm_polyval_mul x y) == gcm_polyval x y }});
-gcm_polyval_assoc_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \x y z -> gcm_polyval x (gcm_polyval y z) == gcm_polyval (gcm_polyval x y) z }});
-gcm_polyval_xor_thm <- prove_print rme (rewrite (cryptol_ss ()) {{ \(x : [128]) y z -> gcm_polyval x (y ^ z) == (gcm_polyval x y) ^ (gcm_polyval x z) }});
+gcm_polyval_mul_0_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \(x : [128]) (y : [128]) -> gcm_polyval_mul_pmult3 x y == gcm_polyval_mul x y }});
+gcm_polyval_mul_1_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \(x : [128]) (y : [128]) -> gcm_polyval_mul_pmult4 x y == gcm_polyval_mul x y }});
+gcm_polyval_red_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \x -> gcm_polyval_red_pmult x == gcm_polyval_red x }});
+gcm_polyval_red_xor_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \x y -> gcm_polyval_red (x ^ y) == (gcm_polyval_red x) ^ (gcm_polyval_red y) }});
+gcm_polyval_mul_red_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \x y -> gcm_polyval_red (gcm_polyval_mul x y) == gcm_polyval x y }});
+gcm_polyval_assoc_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \x y z -> gcm_polyval x (gcm_polyval y z) == gcm_polyval (gcm_polyval x y) z }});
+gcm_polyval_xor_thm <- prove_theorem rme (rewrite (cryptol_ss ()) {{ \(x : [128]) y z -> gcm_polyval x (y ^ z) == (gcm_polyval x y) ^ (gcm_polyval x z) }});
 append_xor_thm <- prove_folding_theorem
   {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) (x8 : [8]) (x9 : [8]) (x10 : [8]) (x11 : [8]) (x12 : [8]) (x13 : [8]) (x14 : [8]) (x15 : [8]) y0 y1 y2 y3 y4 y5 y6 y7 y8 y9 y10 y11 y12 y13 y14 y15 -> ((((((((((((((((x0 ^ y0) # (x1 ^ y1)) # (x2 ^ y2)) # (x3 ^ y3)) # (x4 ^ y4)) # (x5 ^ y5)) # (x6 ^ y6)) # (x7 ^ y7)) # (x8 ^ y8)) # (x9 ^ y9)) # (x10 ^ y10)) # (x11 ^ y11)) # (x12 ^ y12)) # (x13 ^ y13)) # (x14 ^ y14)) # (x15 ^ y15)) == (x0 # x1 # x2 # x3 # x4 # x5 # x6 # x7 # x8 # x9 # x10 # x11 # x12 # x13 # x14 # x15) ^ (y0 # y1 # y2 # y3 # y4 # y5 # y6 # y7 # y8 # y9 # y10 # y11 # y12 # y13 # y14 # y15) }};
 append_slice_thm <- prove_folding_theorem
@@ -228,7 +227,7 @@ let gcm_polyval_thms =
   , append_slice_thm
   ];
 
-let prove_gcm_ghash_avx_thm len = prove_print
+let prove_gcm_ghash_avx_thm len = prove_theorem
   (do {
     goal_eval_unint ["pmult", "pmod", "gcm_polyval", "gcm_polyval_mul", "gcm_polyval_mul_pmult3", "gcm_polyval_mul_pmult4", "gcm_polyval_red", "gcm_polyval_red_pmult"];
     simplify (addsimps gcm_polyval_thms empty_ss);
@@ -244,7 +243,7 @@ let gcm_ghash_avx_thms =
   , gcm_ghash_avx_decrypt_thm
   ];
 
-let prove_ctr32_encrypt_thm gcm_len len = prove_print
+let prove_ctr32_encrypt_thm gcm_len len = prove_theorem
   (do {
     w4_unint_yices ["aes_hw_encrypt"];
   })
@@ -257,7 +256,7 @@ let ctr32_encrypt_thms =
   , ctr32_encrypt_decrypt_thm
   ];
 
-let prove_cipher_update_avx_thm enc gcm_len len = prove_print
+let prove_cipher_update_avx_thm enc gcm_len len = prove_theorem
   (do {
     unfolding ["cipher_update", "cipher_update_byte"];
     simplify (cryptol_ss ());
@@ -278,26 +277,555 @@ let cipher_update_avx_thms =
   , decrypt_update_avx_thm
   ];
 
-aesenc_key0_0_thm <- prove_print
+aesenc_key0_0_thm <- prove_theorem
   (do {
     w4_unint_yices ["AESRound", "AESFinalRound"];
   })
   (rewrite (cryptol_ss ()) {{ \(x : [96]) (y : [32]) key0 key1 -> aesenc ((x # y) ^ key0) key1 == aesenc (key0 ^ (x # y)) key1 }});
-aesenc_key0_1_thm <- prove_print
+aesenc_key0_1_thm <- prove_theorem
   (do {
     w4_unint_yices ["AESRound", "AESFinalRound"];
   })
   (rewrite (cryptol_ss ()) {{ \(x : [120]) (y : [8]) key0 key1 -> aesenc ((x # y) ^ key0) key1 == aesenc (key0 ^ (x # y)) key1 }});
-aesenclast_thm <- prove_print
+aesenclast_thm <- prove_theorem
   (do {
     w4_unint_yices ["ShiftRows", "SubBytes"];
   })
   (rewrite (cryptol_ss ()) {{ \x y z -> aesenclast x (y ^ z) == (aesenclast x y) ^ z }});
-aesenc_aesenclast_thm <- prove_print
+aesenc_aesenclast_thm <- prove_theorem
   (do {
     w4_unint_yices ["AESRound", "AESFinalRound"];
   })
   (rewrite (cryptol_ss ()) {{ \in key0 key1 key2 key3 key4 key5 key6 key7 key8 key9 key10 key11 key12 key13 key14 -> aesenclast (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (key0 ^ in) key1) key2) key3) key4) key5) key6) key7) key8) key9) key10) key11) key12) key13) key14 == swap8 (aesEncryptWithKeySchedule (swap8 in) (aes_key_to_schedule [key0, key1, key2, key3, key4, key5, key6, key7, key8, key9, key10, key11, key12, key13, key14])) }});
+aesenc_aesenclast_1_thm <- prove_theorem
+  (do {
+    w4_unint_yices ["AESRound", "AESFinalRound"];
+  })
+  (normalize_term_opaque ["aesenc", "aesenclast", "aesEncryptWithKeySchedule", "aes_key_to_schedule", "swap8"] (rewrite (cryptol_ss ()) {{ \in (key : [32][8]) key2 key3 key4 key5 key6 key7 key8 key9 key10 key11 key12 key13 key14 -> aesenclast (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc (aesenc in ((key @ 31) # (key @ 30) # (key @ 29) # (key @ 28) # (key @ 27) # (key @ 26) # (key @ 25) # (key @ 24) # (key @ 23) # (key @ 22) # (key @ 21) # (key @ 20) # (key @ 19) # (key @ 18) # (key @ 17) # (key @ 16))) key2) key3) key4) key5) key6) key7) key8) key9) key10) key11) key12) key13) key14 == swap8 (aesEncryptWithKeySchedule (swap8 (in ^ ((key @ 15) # (key @ 14) # (key @ 13) # (key @ 12) # (key @ 11) # (key @ 10) # (key @ 9) # (key @ 8) # (key @ 7) # (key @ 6) # (key @ 5) # (key @ 4) # (key @ 3) # (key @ 2) # (key @ 1) # (key @ 0)))) (aes_key_to_schedule [((key @ 15) # (key @ 14) # (key @ 13) # (key @ 12) # (key @ 11) # (key @ 10) # (key @ 9) # (key @ 8) # (key @ 7) # (key @ 6) # (key @ 5) # (key @ 4) # (key @ 3) # (key @ 2) # (key @ 1) # (key @ 0)), ((key @ 31) # (key @ 30) # (key @ 29) # (key @ 28) # (key @ 27) # (key @ 26) # (key @ 25) # (key @ 24) # (key @ 23) # (key @ 22) # (key @ 21) # (key @ 20) # (key @ 19) # (key @ 18) # (key @ 17) # (key @ 16)), key2, key3, key4, key5, key6, key7, key8, key9, key10, key11, key12, key13, key14])) }}));
+aesEncryptWithKeySchedule_swap8_0_thm <- prove_theorem
+  (do {
+    w4_unint_yices ["aesEncryptWithKeySchedule"];
+  })
+  (rewrite (cryptol_ss ()) {{ \x y z -> (swap8 (aesEncryptWithKeySchedule x y)) ^ z == swap8 ((aesEncryptWithKeySchedule x y) ^ (swap8 z)) }});
+aesEncryptWithKeySchedule_swap8_1_thm <- prove_theorem
+  (do {
+    w4_unint_yices ["aesEncryptWithKeySchedule"];
+  })
+  (rewrite (cryptol_ss ()) {{ \x y z -> z ^ (swap8 (aesEncryptWithKeySchedule x y)) == swap8 ((swap8 z) ^ (aesEncryptWithKeySchedule x y)) }});
+
+
+/*
+ * Rewrites for unbounded verification.
+ */
+append_slice_4_8_thm <- prove_folding_theorem
+  {{ \(y : [96]) x -> (((y # (slice_0_8_24 x)) # (slice_8_8_16 x)) # (slice_16_8_8 x)) # (slice_24_8_0 x) ==  y # x }};
+foo_append_slice_thm <- prove_folding_theorem
+  {{ \x (y : [64]) -> (slice_64_8_56 x) # (slice_72_8_48 x) # (slice_80_8_40 x) # (slice_88_8_32 x) # (slice_96_8_24 x) # (slice_104_8_16 x) # (slice_112_8_8 x) # (slice_120_8_0 x) # y == (slice_64_64_0 x) # y }};
+bar_append_slice_thm <- prove_folding_theorem
+  {{ \x (y : [64]) -> (slice_0_8_120 x) # (slice_8_8_112 x) # (slice_16_8_104 x) # (slice_24_8_96 x) # (slice_32_8_88 x) # (slice_40_8_80 x) # (slice_48_8_72 x) # (slice_56_8_64 x) # y == (slice_0_64_64 x) # y }};
+append_0_xor_thm <- prove_folding_theorem
+  {{ \x (y : [64]) -> (0 : [64]) # (x ^ y) == (0 # x) ^ (0 # y) }};
+append_xor_0_thm <- prove_folding_theorem
+  {{ \x (y : [64]) -> (x ^ y) # (0 : [64]) == (x # 0) ^ (y # 0) }};
+append_add_thm <- prove_folding_theorem
+  {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) (x8 : [8]) (x9 : [8]) (x10 : [8]) (x11 : [8]) (x12 : [8]) (x13 : [8]) (x14 : [8]) (x15 : [8]) y -> ((((((((((((((((y + x0) # x1) # x2) # x3) # x4) # x5) # x6) # x7) # x8) # x9) # x10) # x11) # x12) # x13) # x14) # x15) == (((((((((((((((x0 # x1) # x2) # x3) # x4) # x5) # x6) # x7) # x8) # x9) # x10) # x11) # x12) # x13) # x14) # x15) + (y # 0) }};
+
+append_assoc_0_thm <- prove_folding_theorem
+  {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) (x8 : [8]) (x9 : [8]) (x10 : [8]) (x11 : [8]) (x12 : [8]) (x13 : [8]) (x14 : [8]) (x15 : [8]) -> (((((((x0 # x1) # x2) # x3) # x4) # x5) # x6) # x7) # (((((((x8 # x9) # x10) # x11) # x12) # x13) # x14) # x15) == (((((((((((((((x0 # x1) # x2) # x3) # x4) # x5) # x6) # x7) # x8) # x9) # x10) # x11) # x12) # x13) # x14) # x15) }};
+append_assoc_1_thm <- prove_folding_theorem
+  {{ \(y : [96]) (x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) -> y # (((x0 # x1) # x2) # x3) == (((y # x0) # x1) # x2) # x3 }};
+
+slt_0_thm <- prove_folding_theorem
+  {{ \(x : [32]) -> 100663296 + ((0 : [1]) # x) <$ 0 == ((0 : [1]) # (take`{8} x)) + 6 <$ 0 }};
+slt_1_thm <- prove_folding_theorem
+  {{ \(x : [32]) -> 100663296 + ((0 : [1]) # (100663296 + x)) <$ 0 == ((0 : [1]) # ((take`{8} x) + 6)) + 6 <$ 0 }};
+ite_slt_1_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # x0) <$ 0 then ((((((swap8 (1 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((1 + x0) # x1) # x2) # x3) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (1 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_2_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # x0) <$ 0 then ((((((swap8 (2 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((2 + x0) # x1) # x2) # x3) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (2 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_3_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # x0) <$ 0 then ((((((swap8 (3 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((3 + x0) # x1) # x2) # x3) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (3 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_4_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # x0) <$ 0 then ((((((swap8 (4 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((4 + x0) # x1) # x2) # x3) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (4 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_5_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # x0) <$ 0 then ((((((swap8 (5 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((5 + x0) # x1) # x2) # x3) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (5 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_6_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # x0) <$ 0 then ((((((swap8 (6 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((6 + x0) # x1) # x2) # x3) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (6 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_7_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # (6 + x0)) <$ 0 then ((((((swap8 (7 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((1 + ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 3)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 2)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 1)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 0)) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (7 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_8_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # (6 + x0)) <$ 0 then ((((((swap8 (8 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((2 + ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 3)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 2)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 1)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 0)) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (8 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_9_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # (6 + x0)) <$ 0 then ((((((swap8 (9 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((3 + ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 3)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 2)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 1)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 0)) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (9 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_10_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # (6 + x0)) <$ 0 then ((((((swap8 (10 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((4 + ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 3)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 2)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 1)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 0)) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (10 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_11_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # (6 + x0)) <$ 0 then ((((((swap8 (11 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((5 + ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 3)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 2)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 1)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 0)) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (11 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_12_thm <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) -> (if 6 + ((0 : [1]) # (6 + x0)) <$ 0 then ((((((swap8 (12 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) : [64]) else (((((((((6 + ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 3)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 2)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 1)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 0)) # x4) # x5) # x6) # x7) : [64])) == (((((swap8 (12 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) }});
+ite_slt_12_thm' <- prove_folding_theorem
+  (normalize_term {{ \(x0 : [8]) (x1 : [8]) (x2 : [8]) (x3 : [8]) (x4 : [8]) (x5 : [8]) (x6 : [8]) (x7 : [8]) (x8 : [8]) (x9 : [8]) (x10 : [8]) (x11 : [8]) (x12 : [8]) (x13 : [8]) (x14 : [8]) (x15 : [8]) -> (if 6 + ((0 : [1]) # (6 + x0)) <$ 0 then ((((((((((((((swap8 (12 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) # x8) # x9) # x10) # x11) # x12) # x13) # x14) # x15) : [128]) else (((((((((((((((((6 + ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 3)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 2)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 1)) # ((split`{4} (6 + (((x3 # x2) # x1) # x0))) @ 0)) # x4) # x5) # x6) # x7) # x8) # x9) # x10) # x11) # x12) # x13) # x14) # x15) : [128])) == (((((((((((((swap8 (12 + (((x3 # x2) # x1) # x0))) # x4) # x5) # x6) # x7) # x8) # x9) # x10) # x11) # x12) # x13) # x14) # x15) }});
+add_ite_thm <- prove_folding_theorem {{ \(x : [64]) y z c -> (x + if c then y else z) == (if c then x + y else x + z) }};
+
+let {{
+  arrayRangeLookup_impl64 : Array[64][8] -> [64] -> [64] -> [64] -> [64]
+  arrayRangeLookup_impl64 a i j k =
+    (((arrayLookup a ((if i == 0 then j else i + j) + k)) # (arrayLookup a (((i + 1) + j) + k)))
+    # ((arrayLookup a (((i + 2) + j) + k)) # (arrayLookup a (((i + 3) + j) + k))))
+    # (((arrayLookup a (((i + 4) + j) + k)) # (arrayLookup a (((i + 5) + j) + k)))
+      # ((arrayLookup a (((i + 6) + j) + k)) # (arrayLookup a (((i + 7) + j) + k))))
+}};
+
+arrayRangeLookup_impl64_0_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 0 n m == loadHalfBlock a (n + m) }}));
+arrayRangeLookup_impl64_8_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 8 n m == loadHalfBlock a (n + m + 8) }}));
+arrayRangeLookup_impl64_16_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 16 n m == loadHalfBlock a (n + m + 16) }}));
+arrayRangeLookup_impl64_24_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 24 n m == loadHalfBlock a (n + m + 24) }}));
+arrayRangeLookup_impl64_32_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 32 n m == loadHalfBlock a (n + m + 32) }}));
+arrayRangeLookup_impl64_40_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 40 n m == loadHalfBlock a (n + m + 40) }}));
+arrayRangeLookup_impl64_48_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 48 n m == loadHalfBlock a (n + m + 48) }}));
+arrayRangeLookup_impl64_56_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 56 n m == loadHalfBlock a (n + m + 56) }}));
+arrayRangeLookup_impl64_64_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 64 n m == loadHalfBlock a (n + m + 64) }}));
+arrayRangeLookup_impl64_72_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 72 n m == loadHalfBlock a (n + m + 72) }}));
+arrayRangeLookup_impl64_80_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 80 n m == loadHalfBlock a (n + m + 80) }}));
+arrayRangeLookup_impl64_88_thm <- prove_theorem
+  w4
+  (normalize_term_opaque ["loadHalfBlock"] ({{ \a n m -> arrayRangeLookup_impl64 a 88 n m == loadHalfBlock a (n + m + 88) }}));
+
+
+/*
+ * AESNI-GCM rewrite rules.
+ */
+let arrayEq = parse_core "arrayEq (Vec 64 Bool) (Vec 8 Bool)";
+let pairEq = parse_core "pairEq (Array (Vec 64 Bool) (Vec 8 Bool)) ((Vec 128 Bool) * (Vec 128 Bool)) (arrayEq (Vec 64 Bool) (Vec 8 Bool)) (pairEq (Vec 128 Bool) (Vec 128 Bool) (bvEq 128) (bvEq 128))";
+
+let {{
+  aesEncryptWithKeySchedule_ExpandKey_stmt blk key =
+      aesEncryptWithKeySchedule blk ((ExpandKey key).0, (ExpandKey key).1, (ExpandKey key).2)
+      == aesEncryptWithKeySchedule blk (transpose (split (split (hi_bits key))), [transpose (split (split (lo_bits key)))] # (drop`{1} middle_keys), final_key)
+    where
+      (_init_key, middle_keys, final_key) = ExpandKey key
+}};
+aesEncryptWithKeySchedule_ExpandKey_thm <- prove_theorem
+  (do {
+    w4_unint_yices ["aesEncryptWithKeySchedule", "NextWord"];
+  })
+  (rewrite (cryptol_ss ()) (unfold_term ["aesEncryptWithKeySchedule_ExpandKey_stmt"] {{ aesEncryptWithKeySchedule_ExpandKey_stmt }}));
+
+aes_encrypt_blocks_6_impl_thm <- prove_theorem
+  (do {
+    goal_normalize ["aesEncryptWithKeySchedule", "ExpandKey"];
+    w4_unint_z3 ["aesEncryptWithKeySchedule", "ExpandKey"];
+  })
+  (rewrite (cryptol_ss ()) {{ \key (iv : [12][8]) (ctr : [4][8]) (block_index : [64]) blocks ->
+    aes_encrypt_blocks_6_impl
+      key
+      (0 # ((swap8 (join ctr)) + (((drop block_index) : [8]) # 0)))
+      (0 # (swap8 ((join iv) # ((join ctr) + (drop block_index)))))
+      (0 # ((swap8 ((join iv) # ((join ctr) + (drop block_index)))) ^ (join (reverse (take key)))))
+      (0 # ((swap8 ((join iv) # ((join ctr) + (drop block_index)))) + ((1 : [8]) # 0)))
+      (0 # ((swap8 ((join iv) # ((join ctr) + (drop block_index)))) + ((2 : [8]) # 0)))
+      (0 # ((swap8 ((join iv) # ((join ctr) + (drop block_index)))) + ((3 : [8]) # 0)))
+      (0 # ((swap8 ((join iv) # ((join ctr) + (drop block_index)))) + ((4 : [8]) # 0)))
+      (0 # ((swap8 ((join iv) # ((join ctr) + (drop block_index)))) + ((5 : [8]) # 0)))
+      blocks
+    == ((swap8 ((join iv) # ((join ctr) + (drop (block_index + 6))))), aes_ctr32_encrypt_blocks (join key) (join iv) ((join ctr) + (drop block_index)) blocks) }});
+
+gcm_polyval_red_half_pmult_thm <- prove_theorem
+  (w4_unint_yices ["gcm_polyval_red_half_pmult"])
+  (rewrite (cryptol_ss ()) {{ \x0 x1 -> (gcm_polyval_red_half_pmult (gcm_polyval_red_half_pmult x0)) ^ x1 == gcm_polyval_red_pmult (x1 # x0) }});
+
+gcm_ghash_blocks_6_pmult4_thm <- prove_theorem
+  (do {
+    goal_eval_unint ["pmult", "pmod", "gcm_polyval", "gcm_polyval_mul", "gcm_polyval_red", "gcm_pmult_pmod", "gcm_polyval_mul_pmult3", "gcm_polyval_mul_pmult4", "gcm_polyval_red_half_pmult", "gcm_init_H", "get_H'"];
+    simplify (addsimps [gcm_pmult_pmod_thm, gcm_polyval_mul_0_thm, gcm_polyval_mul_1_thm, gcm_polyval_red_thm, gcm_polyval_red_xor_thm, gcm_polyval_mul_red_thm, gcm_polyval_assoc_thm, gcm_polyval_xor_thm, gcm_polyval_red_half_pmult_thm, gcm_polyval_red_thm] empty_ss);
+    goal_eval_unint ["pmult", "pmod", "gcm_polyval", "gcm_polyval_mul", "gcm_polyval_red", "gcm_pmult_pmod", "gcm_polyval_mul_pmult3", "gcm_polyval_mul_pmult4", "gcm_polyval_red_half_pmult", "gcm_init_H", "get_H'"];
+    simplify (addsimps [gcm_pmult_pmod_thm, gcm_polyval_mul_0_thm, gcm_polyval_mul_1_thm, gcm_polyval_red_thm, gcm_polyval_red_xor_thm, gcm_polyval_mul_red_thm, gcm_polyval_assoc_thm, gcm_polyval_xor_thm, gcm_polyval_red_half_pmult_thm, gcm_polyval_red_thm] empty_ss);
+    w4_unint_z3 ["pmult", "pmod", "gcm_polyval", "gcm_polyval_mul", "gcm_polyval_red", "gcm_pmult_pmod", "gcm_polyval_mul_pmult3", "gcm_polyval_mul_pmult4", "gcm_polyval_red_half_pmult", "gcm_init_H", "get_H'"];
+  })
+  (rewrite (cryptol_ss ()) ({{ \key Xi blocks -> gcm_ghash_blocks (gcm_init_H (join (get_H' key))) Xi blocks == combine_Xi_triple (gcm_polyval_pmult4_impl key 0 Xi 0 blocks) }}));
+
+gcm_ghash_blocks_6_pmult3_thm <- prove_theorem
+  (do {
+    goal_eval_unint ["gcm_polyval_mul_pmult3", "gcm_polyval_mul_pmult4", "gcm_polyval_red_half_pmult", "get_Htable"];
+    simplify (addsimps [gcm_polyval_mul_0_thm, gcm_polyval_mul_1_thm] empty_ss);
+    w4_unint_z3 ["gcm_polyval_mul", "gcm_polyval_red_half_pmult", "get_Htable"];
+  })
+  (rewrite (cryptol_ss ()) ({{ \key Xi_0 Xi_1 Xi_2 blocks -> gcm_polyval_pmult3_impl key Xi_0 Xi_1 Xi_2 blocks == gcm_polyval_pmult4_impl key 0 (Xi_0 ^ Xi_1 ^ Xi_2) 0 blocks }}));
+
+
+let split_ite then_script else_script = do {
+  hoist_ifs_in_goal;
+  simplify (add_prelude_eqs ["ite_bit"] (cryptol_ss ())); // try to split only the top ite
+  split_goal;
+  then_script;
+  else_script;
+};
+
+
+let {{
+  aesni_gcm_encrypt_impl_loop_step' = aesni_gcm_encrypt_impl_loop_step
+}};
+
+out_and_tag_aesni_gcm_encrypt_impl_loop_thm <- prove_theorem
+  (do {
+    unfolding_fix_once ["aesni_gcm_encrypt_impl_loop"];
+    w4_unint_yices ["pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_encrypt_impl_loop", "get_encrypt_output_and_tag" ,"get_Htable", "gcm_polyval_mul_pmult4", "gcm_polyval_mul_pmult3", "gcm_polyval_red_half_pmult"];
+  })
+  (rewrite (cryptol_ss ()) {{ \len in out key iv ctr Xi loop_tuple ->
+    pairEq
+      (get_encrypt_output_and_tag key (aesni_gcm_encrypt_impl_loop_step' len in out key iv ctr Xi (aesni_gcm_encrypt_impl_loop len in out key iv ctr Xi (aesni_gcm_encrypt_impl_loop_step len in out key iv ctr Xi loop_tuple))))
+      (get_encrypt_output_and_tag key (aesni_gcm_encrypt_impl_loop_step' len in out key iv ctr Xi (aesni_gcm_encrypt_impl_loop len in out key iv ctr Xi (combine_Xi_parts (aesni_gcm_encrypt_impl_loop_step len in out key iv ctr Xi loop_tuple)))))
+  }});
+
+let {{
+  aesni_gcm_encrypt_impl_loop_stmt len in out key iv ctr Xi loop_index current_out current_Xi = pairEq
+    (aesni_gcm_encrypt len in out key iv ctr Xi loop_index current_out current_Xi)
+    (if (6 * loop_index <= (len / 16) - 18) && (288 <= len) && (len < 68719476736) && (loop_index <= ((len / 16) / 6) - 3) then
+      (get_encrypt_output_and_tag key
+        (aesni_gcm_encrypt_impl_loop_step' len in out key iv ctr Xi
+          (aesni_gcm_encrypt_impl_loop len in out key iv ctr Xi
+            ( impl_out
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 72))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 64))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 56))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 48))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 40))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 32))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 24))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 16))
+            , 0
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index + 8))
+            , join (arrayRangeLookup`{n=8} impl_out (96 * loop_index))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index + 12))))) + ((5 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index + 12))))) + ((4 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index + 12))))) + ((3 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index + 12))))) + ((2 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index + 12))))) + ((1 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index + 12))))) ^ (join (reverse (take key))))
+            , 0 # current_Xi
+            , 0 # (join (arrayRangeLookup`{n=16} impl_out (96 * loop_index + 80)))
+            , 0
+            , 0 # (swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index + 12)))))
+            , 96 * loop_index
+            , 0 # ((swap8 (join ctr)) + (((drop (6 * loop_index + 12)) : [8]) # 0))
+            , loop_index
+            ))))
+    else
+      (aesni_gcm_encrypt len in out key iv ctr Xi loop_index current_out current_Xi))
+   where
+    impl_out = arrayRangeUpdate
+      (arrayRangeUpdate
+        current_out
+        (loop_index * 96)
+        (split (join (aes_ctr32_encrypt_blocks`{6} (join key) (join iv) ((join ctr) + (drop (6 * loop_index)))
+          (split (join (arrayRangeLookup in (loop_index * 96))))))))
+      (loop_index * 96 + 96)
+      (split (join (aes_ctr32_encrypt_blocks`{6} (join key) (join iv) ((join ctr) + (drop (6 * (loop_index + 1))))
+        (split (join (arrayRangeLookup in (loop_index * 96 + 96)))))))
+}};
+
+aesni_gcm_encrypt_impl_loop_hyp <- prove_theorem assume_unsat (rewrite (cryptol_ss ()) (unfold_term ["aesni_gcm_encrypt_impl_loop_stmt"] {{ aesni_gcm_encrypt_impl_loop_stmt }}));
+let aesni_gcm_encrypt_unints =
+  [ "aesni_gcm_encrypt"
+  , "aesni_gcm_encrypt_impl_loop"
+  , "aesni_gcm_encrypt_impl_loop_step"
+  , "aesni_gcm_encrypt_impl_loop_step'"
+  , "get_encrypt_output_and_tag"
+  , "aes_ctr32_encrypt_block"
+  , "gcm_ghash_block"
+  , "gcm_polyval_pmult4_impl"
+  , "gcm_polyval_pmult3_impl"
+  , "get_H'"
+  , "gcm_init_H"
+  ];
+aesni_gcm_encrypt_impl_loop_thm <- prove_theorem
+  (do {
+    split_ite (do {
+      unfolding_fix_once ["aesni_gcm_encrypt"];
+
+      split_ite (do {
+        unfolding_fix_once ["aesni_gcm_encrypt_impl_loop"];
+
+        split_ite (do {
+          simplify (addsimp_shallow aesni_gcm_encrypt_impl_loop_hyp (cryptol_ss ()));
+
+          split_ite (do {
+            simplify (addsimps [out_and_tag_aesni_gcm_encrypt_impl_loop_thm] (cryptol_ss ()));
+            unfolding ["aesni_gcm_encrypt_impl_loop_step"];
+            simplify (addsimps [aes_encrypt_blocks_6_impl_thm, gcm_ghash_blocks_6_pmult4_thm] (cryptol_ss ()));
+            goal_eval_unint aesni_gcm_encrypt_unints;
+
+            split_ite (do {
+              goal_eval_unint aesni_gcm_encrypt_unints;
+              w4_unint_z3 aesni_gcm_encrypt_unints;
+            }) (do {
+              goal_eval_unint aesni_gcm_encrypt_unints;
+              w4_unint_z3 aesni_gcm_encrypt_unints;
+            });
+          }) (do {
+            goal_eval_unint aesni_gcm_encrypt_unints;
+            w4_unint_z3 aesni_gcm_encrypt_unints;
+          });
+        }) (do {
+          unfolding_fix_once ["aesni_gcm_encrypt"];
+
+          split_ite (do {
+            unfolding_fix_once ["aesni_gcm_encrypt"];
+
+            split_ite (do {
+              unfolding_fix_once ["aesni_gcm_encrypt"];
+
+              split_ite (do {
+                goal_eval_unint aesni_gcm_encrypt_unints;
+                w4_unint_z3 aesni_gcm_encrypt_unints;
+              }) (do {
+                unfolding ["aesni_gcm_encrypt_impl_loop_step", "aesni_gcm_encrypt_impl_loop_step'", "get_encrypt_output_and_tag"];
+                simplify (addsimps [aes_encrypt_blocks_6_impl_thm, gcm_ghash_blocks_6_pmult4_thm, gcm_ghash_blocks_6_pmult3_thm] (cryptol_ss ()));
+                goal_eval_unint aesni_gcm_encrypt_unints;
+
+                split_ite (do {
+                  goal_eval_unint aesni_gcm_encrypt_unints;
+                  w4_unint_z3 aesni_gcm_encrypt_unints;
+                }) (do {
+                  goal_eval_unint aesni_gcm_encrypt_unints;
+                  w4_unint_z3 aesni_gcm_encrypt_unints;
+                });
+              });
+            }) (do {
+              goal_eval_unint aesni_gcm_encrypt_unints;
+              w4_unint_z3 aesni_gcm_encrypt_unints;
+            });
+          }) (do {
+            goal_eval_unint aesni_gcm_encrypt_unints;
+            w4_unint_z3 aesni_gcm_encrypt_unints;
+          });
+        });
+      }) (do {
+        goal_eval_unint aesni_gcm_encrypt_unints;
+        w4_unint_z3 aesni_gcm_encrypt_unints;
+      });
+    }) (do {
+      w4_unint_z3 aesni_gcm_encrypt_unints;
+    });
+  })
+  (rewrite (cryptol_ss ()) (unfold_term ["aesni_gcm_encrypt_impl_loop_stmt"] {{ aesni_gcm_encrypt_impl_loop_stmt }}));
+
+
+let {{
+  aesni_gcm_decrypt_impl_loop_step' = aesni_gcm_decrypt_impl_loop_step
+}};
+
+out_and_tag_aesni_gcm_decrypt_impl_loop_thm <- prove_theorem
+  (do {
+    unfolding_fix_once ["aesni_gcm_decrypt_impl_loop"];
+    w4_unint_yices ["pmult", "pmod", "gcm_polyval", "aesEncryptWithKeySchedule", "ExpandKey", "aesni_gcm_decrypt_impl_loop", "get_decrypt_output_and_tag", "get_Htable", "gcm_polyval_mul_pmult4", "gcm_polyval_red_half_pmult"];
+  })
+  (rewrite (cryptol_ss ()) {{ \len in out key iv ctr Xi loop_tuple ->
+    pairEq
+      (get_decrypt_output_and_tag (aesni_gcm_decrypt_impl_loop_step' len in out key iv ctr Xi (aesni_gcm_decrypt_impl_loop len in out key iv ctr Xi (aesni_gcm_decrypt_impl_loop_step len in out key iv ctr Xi loop_tuple))))
+      (get_decrypt_output_and_tag (aesni_gcm_decrypt_impl_loop_step' len in out key iv ctr Xi (aesni_gcm_decrypt_impl_loop len in out key iv ctr Xi (combine_Xi_parts (aesni_gcm_decrypt_impl_loop_step len in out key iv ctr Xi loop_tuple)))))
+  }});
+
+let aesni_gcm_decrypt_impl_loop_stmt = rewrite (cryptol_ss ()) {{ \len in out key iv ctr Xi loop_index current_out current_Xi ->
+  pairEq
+    (aesni_gcm_decrypt len in out key iv ctr Xi loop_index current_out current_Xi)
+    (if (loop_index <= ((len / 16) / 6) - 1) && (96 <= len) && (len < 68719476736) then
+      (get_decrypt_output_and_tag
+        (aesni_gcm_decrypt_impl_loop_step' len in out key iv ctr Xi
+          (aesni_gcm_decrypt_impl_loop len in out key iv ctr Xi
+            ( current_out
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 72))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 64))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 56))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 48))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 40))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 32))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 24))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 16))
+            , 0
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index + 8))
+            , join (arrayRangeLookup`{n=8} in (96 * loop_index))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index))))) + ((5 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index))))) + ((4 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index))))) + ((3 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index))))) + ((2 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index))))) + ((1 : [8]) # 0))
+            , 0 # ((swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index))))) ^ (join (reverse (take key))))
+            , 0 # current_Xi
+            , 0 # (join (arrayRangeLookup`{n=16} in (96 * loop_index + 80)))
+            , 0
+            , 0 # (swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index)))))
+            , 96 * loop_index
+            , 0 # ((swap8 (join ctr)) + (((drop (6 * loop_index)) : [8]) # 0))
+            , loop_index
+            ))))
+    else
+      (aesni_gcm_decrypt len in out key iv ctr Xi loop_index current_out current_Xi))
+  }};
+
+aesni_gcm_decrypt_impl_loop_hyp <- prove_theorem assume_unsat aesni_gcm_decrypt_impl_loop_stmt;
+let aesni_gcm_decrypt_unints =
+  [ "aesni_gcm_decrypt"
+  , "aesni_gcm_decrypt_impl_loop"
+  , "aesni_gcm_decrypt_impl_loop_step"
+  , "aesni_gcm_decrypt_impl_loop_step'"
+  , "get_decrypt_output_and_tag"
+  , "aes_ctr32_encrypt_block"
+  , "gcm_ghash_block"
+  , "gcm_polyval_pmult4_impl"
+  , "gcm_polyval_pmult3_impl"
+  , "get_H'"
+  , "gcm_init_H"
+  ];
+aesni_gcm_decrypt_impl_loop_thm <- prove_theorem
+  (do {
+    split_ite (do {
+      unfolding_fix_once ["aesni_gcm_decrypt"];
+
+      split_ite (do {
+        unfolding_fix_once ["aesni_gcm_decrypt_impl_loop"];
+
+        split_ite (do {
+          simplify (addsimp_shallow aesni_gcm_decrypt_impl_loop_hyp (cryptol_ss ()));
+
+          split_ite (do {
+            simplify (addsimps [out_and_tag_aesni_gcm_decrypt_impl_loop_thm] (cryptol_ss ()));
+            unfolding ["aesni_gcm_decrypt_impl_loop_step"];
+            simplify (addsimps [aes_encrypt_blocks_6_impl_thm, gcm_ghash_blocks_6_pmult4_thm] (cryptol_ss ()));
+            goal_eval_unint aesni_gcm_decrypt_unints;
+
+            split_ite (do {
+              goal_eval_unint aesni_gcm_decrypt_unints;
+              w4_unint_z3 aesni_gcm_decrypt_unints;
+            }) (do {
+              goal_eval_unint aesni_gcm_decrypt_unints;
+              w4_unint_z3 aesni_gcm_decrypt_unints;
+            });
+          }) (do {
+            goal_eval_unint aesni_gcm_decrypt_unints;
+            w4_unint_z3 aesni_gcm_decrypt_unints;
+          });
+        }) (do {
+          unfolding_fix_once ["aesni_gcm_decrypt"];
+
+          split_ite (do {
+            goal_eval_unint aesni_gcm_decrypt_unints;
+            w4_unint_z3 aesni_gcm_decrypt_unints;
+          }) (do {
+            unfolding ["aesni_gcm_decrypt_impl_loop_step", "aesni_gcm_decrypt_impl_loop_step'", "get_decrypt_output_and_tag"];
+            simplify (addsimps [aes_encrypt_blocks_6_impl_thm, gcm_ghash_blocks_6_pmult4_thm] (cryptol_ss ()));
+            goal_eval_unint aesni_gcm_decrypt_unints;
+            w4_unint_z3 aesni_gcm_decrypt_unints;
+          });
+        });
+      }) (do {
+        goal_eval_unint aesni_gcm_decrypt_unints;
+        w4_unint_z3 aesni_gcm_decrypt_unints;
+      });
+    }) (do {
+      w4_unint_z3 aesni_gcm_decrypt_unints;
+    });
+  })
+  aesni_gcm_decrypt_impl_loop_stmt;
+
+let aesni_gcm_encrypt_Yi_stmt = rewrite (cryptol_ss ()) {{ \len in out key iv ctr Xi i out' Xi' ->
+  (aesni_gcm_encrypt len in out key iv ctr Xi i out' Xi').2
+  == (join iv) # ((join ctr) + (drop (6 * ((len / 16) / 6))))
+}};
+aesni_gcm_encrypt_Yi_hyp <- prove_theorem assume_unsat aesni_gcm_encrypt_Yi_stmt;
+aesni_gcm_encrypt_Yi_thm <- prove_theorem
+  (do {
+    unfolding_fix_once ["aesni_gcm_encrypt"];
+    hoist_ifs_in_goal;
+    simplify (addsimps [aesni_gcm_encrypt_Yi_hyp] empty_ss);
+    w4_unint_z3 ["aesni_gcm_encrypt"];
+  })
+  aesni_gcm_encrypt_Yi_stmt;
+
+let aesni_gcm_decrypt_Yi_stmt = rewrite (cryptol_ss ()) {{ \len in out key iv ctr Xi i out' Xi' ->
+  (aesni_gcm_decrypt len in out key iv ctr Xi i out' Xi').2
+  == (join iv) # ((join ctr) + (drop (6 * ((len / 16) / 6))))
+}};
+aesni_gcm_decrypt_Yi_hyp <- prove_theorem assume_unsat aesni_gcm_decrypt_Yi_stmt;
+aesni_gcm_decrypt_Yi_thm <- prove_theorem
+  (do {
+    unfolding_fix_once ["aesni_gcm_decrypt"];
+    hoist_ifs_in_goal;
+    simplify (addsimps [aesni_gcm_decrypt_Yi_hyp] empty_ss);
+    w4_unint_z3 ["aesni_gcm_decrypt"];
+  })
+  aesni_gcm_decrypt_Yi_stmt;
+
+
+/*
+ * EVP specific rewrite rules.
+ */
+let {{
+  arrayLookupUnint : Array[64][8] -> [64] -> [8]
+  arrayLookupUnint = arrayLookup
+  arrayUpdateUnint : Array[64][8] -> [64] -> [8] -> Array[64][8]
+  arrayUpdateUnint = arrayUpdate
+  arrayCopyUnint : Array[64][8] -> [64] -> Array[64][8] -> [64] -> [64] -> Array[64][8]
+  arrayCopyUnint = arrayCopy
+  arrayConstantUnint : [8] -> Array[64][8]
+  arrayConstantUnint = arrayConstant
+}};
+arrayLookupUnint_thm <- prove_theorem
+  (w4_unint_z3 [])
+  (rewrite (cryptol_ss ()) {{ \a i -> arrayLookup a i == arrayLookupUnint a i }});
+arrayUpdateUnint_thm <- prove_theorem
+  (w4_unint_z3 [])
+  (rewrite (cryptol_ss ()) {{ \a i x -> arrayEq (arrayUpdate a i x) (arrayUpdateUnint a i x) }});
+arrayCopyUnint_thm <- prove_theorem
+  (w4_unint_z3 [])
+  (rewrite (cryptol_ss ()) {{ \a i b j n -> arrayEq (arrayCopy a i b j n) (arrayCopyUnint a i b j n) }});
+arrayConstantUnint_thm <- prove_theorem
+  (w4_unint_z3 [])
+  (rewrite (cryptol_ss ()) {{ \x -> arrayEq (arrayConstant x) (arrayConstantUnint x) }});
+
+bvand_bvudiv_thm <- prove_folding_theorem {{ \x -> 0xfffffffffffffff0 && x == 16 * (x / 16) }};
+bvudiv_bvmul_bvudiv_thm <- prove_folding_theorem {{ \(x : [64]) -> (16 * (x / 16)) / 16 == x / 16 }};
+bvurem_16_append_thm <- prove_folding_theorem {{ \(x : [60]) (y : [4]) -> (x # y) % 16 == 0 # y }};
+ite_bveq_0_thm <- prove_folding_theorem (normalize_term {{ \(x : [64]) y -> (if x == y then x else y) == y }});
+ite_bveq_1_thm <- prove_folding_theorem (normalize_term {{ \(x : [64]) y -> (if x == y then y else x) == x }});
+bveq_ite_bv8_0_thm <- prove_folding_theorem (normalize_term {{ \b (x : [8]) y z -> ((if b then x else y) == (if b then x else z)) == if b then True else y == z }});
+bveq_ite_bv8_1_thm <- prove_folding_theorem (normalize_term {{ \b (x : [8]) y z -> ((if b then y else x) == (if b then z else x)) == if b then y == z else True }});
+arrayeq_ite_0_thm <- prove_folding_theorem {{ \b (x : Array[64][8]) y z -> arrayEq (if b then x else y) (if b then x else z) == if b then True else arrayEq y z }};
+arrayeq_ite_1_thm <- prove_folding_theorem {{ \b (x : Array[64][8]) y z -> arrayEq (if b then y else x) (if b then z else x) == if b then arrayEq y z else True }};
+foo_thm <- prove_folding_theorem {{ \(x : [64]) b c -> (
+  (x_55 + x_70) + c == 16 * (x / 16) + c
+  where
+    x_55 = (if b then 0 else 96 * (x / 96))
+    x_70 = 16 * ((x + (-1) * x_55) / 16)
+)}};
+bar_thm <- prove_folding_theorem {{ \(x : [64]) b c -> (
+  (c + x_149) + x_147 == 16 * (x / 16) + c
+  where
+    x_147 = (if b then 0 else 96 * (x / 96))
+    x_149 = 16 * ((x + (-1) * x_147) / 16)
+)}};
 
 
 /*

--- a/SAW/proof/common/helpers.saw
+++ b/SAW/proof/common/helpers.saw
@@ -77,7 +77,17 @@ let llvm_verify m func overrides pathsat spec tactic = if do_prove
 let llvm_verify_x86 m elf func globals pathsat spec tactic = if do_prove
   then crucible_llvm_verify_x86 m elf func globals pathsat spec tactic
   else crucible_llvm_unsafe_assume_spec m func spec;
+let llvm_verify_fixpoint_x86' m elf func globals pathsat loop_func_term spec tactic = if do_prove
+  then llvm_verify_fixpoint_x86 m elf func globals pathsat loop_func_term spec tactic
+  else crucible_llvm_unsafe_assume_spec m func spec;
+let llvm_refine_spec' m func overrides spec tactic = if do_prove
+  then llvm_refine_spec m func overrides spec tactic
+  else crucible_llvm_unsafe_assume_spec m func spec;
 
-let prove_folding_theorem t = prove_print w4 (rewrite (cryptol_ss ()) t);
+let prove_theorem tac t = if do_prove
+  then prove_print tac t
+  else prove_print assume_unsat t;
+
+let prove_folding_theorem t = prove_theorem w4 (rewrite (cryptol_ss ()) t);
 let assume_folding_theorem t = prove_print assume_unsat (rewrite (cryptol_ss ()) t);
 

--- a/SAW/spec/AES/AES-GCM-implementation.cry
+++ b/SAW/spec/AES/AES-GCM-implementation.cry
@@ -33,15 +33,12 @@ gcm_polyval_mul_pmult4 X Y = (hi ^ (0 : [1 + n]) # (hi_bits (m0 ^ m1))) # (lo ^ 
     m1 = (0 : [1]) # (pmult X_hi Y_lo)
 
 gcm_polyval_red_pmult : [256] -> [128]
-gcm_polyval_red_pmult X = (d1 ^ x3) # (d0 ^ x2)
+gcm_polyval_red_pmult (x1 # x0) = (gcm_polyval_red_half_pmult (gcm_polyval_red_half_pmult x0)) ^ x1
+
+gcm_polyval_red_half_pmult : [128] -> [128]
+gcm_polyval_red_half_pmult X = ((0 : [1]) # (pmult <| x^^63 + x^^62 + x^^57 |> x0)) ^ (x0 # x1)
   where
-    [x3, x2, x1, x0] = split X
-    [a1, a0] = split ((0 : [1]) # (pmult <| x^^63 + x^^62 + x^^57 |> x0))
-    b1 = x0 ^ a1
-    b0 = x1 ^ a0
-    [c1, c0] = split ((0 : [1]) # (pmult <| x^^63 + x^^62 + x^^57 |> b0))
-    d1 = b0 ^ c1
-    d0 = b1 ^ c0
+    [x1, x0] = split X
 
 gcm_polyval_avx : [128] -> [128] -> [128]
 gcm_polyval_avx H X = x30
@@ -88,7 +85,7 @@ aesni_gcm_cipher_block6 enc karatsuba ctx blks = ctx'
     gcm_polyval_mul_fun = if karatsuba
       then gcm_polyval_mul_pmult3
       else gcm_polyval_mul_pmult4
-    Htable = get_Htable ctx
+    Htable = get_Htable ctx.key
     Xi = join ctx.Xi
     Xi_0 = gcm_polyval_mul_fun (Htable @ 0) (blks @ 5)
     Xi_1 = gcm_polyval_mul_fun (Htable @ 1) (blks @ 4)

--- a/SAW/spec/AES/AES-GCM-unbounded.cry
+++ b/SAW/spec/AES/AES-GCM-unbounded.cry
@@ -1,0 +1,584 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+module AES_GCM_Unbounded where
+
+import Array
+
+import Primitive::Symmetric::Cipher::Block::AES
+import Primitive::Symmetric::Cipher::Authenticated::AES_256_GCM
+import AES_GCM
+import AES_GCM_Implementation
+
+type LoopTuple =
+  ( Array[64][8] // Output buffer
+  // stack values
+  , [64], [64], [64], [64], [64], [64], [64], [64]
+  , [128]
+  , [64], [64]
+  // XMM registers
+  , [512], [512], [512], [512], [512], [512], [512], [512], [512], [512]
+  // general purpose registers
+  , [64], [64], [64]
+  )
+
+get_loop_index : LoopTuple -> [64]
+get_loop_index
+  ( out
+  , prefetch9, prefetch8, prefetch7, prefetch6, prefetch5, prefetch4, prefetch3, prefetch2
+  , spill_Z3
+  , prefetch1, prefetch0
+  , inout5, inout4, inout3, inout2, inout1, inout0, loop_Xi, Z3
+  , Z0
+  , T1
+  , prefetch_offset, ctr_least_byte, loop_index
+  ) = loop_index
+
+get_encrypt_output_and_tag : [32][8] -> LoopTuple -> (Array[64][8], [128], [128])
+get_encrypt_output_and_tag key
+  ( out
+  , prefetch9, prefetch8, prefetch7, prefetch6, prefetch5, prefetch4, prefetch3, prefetch2
+  , spill_Z3
+  , prefetch1, prefetch0
+  , inout5, inout4, inout3, inout2, inout1, inout0
+  , loop_Xi
+  , Z3
+  , Z0
+  , T1
+  , prefetch_offset, ctr_least_byte, loop_index
+  ) = (out, res_Xi_part0' ^ res_Xi_part1' ^ res_Xi_part2', swap8 (drop T1))
+ where
+  enc_block0 = prefetch0 # prefetch1
+  enc_block1 = prefetch2 # prefetch3
+  enc_block2 = prefetch4 # prefetch5
+  enc_block3 = prefetch6 # prefetch7
+  enc_block4 = prefetch8 # prefetch9
+  enc_block5 = drop Z3
+  blocks = [enc_block0, enc_block1, enc_block2, enc_block3, enc_block4, enc_block5]
+  (res_Xi_part0, res_Xi_part1, res_Xi_part2) = gcm_polyval_pmult3_impl key spill_Z3 (drop loop_Xi) (drop Z0) blocks
+  blocks' = split (join (arrayRangeLookup out (96 * loop_index + 96)))
+  (res_Xi_part0', res_Xi_part1', res_Xi_part2') = gcm_polyval_pmult3_impl key res_Xi_part0 res_Xi_part1 res_Xi_part2 blocks'
+
+get_decrypt_output_and_tag : LoopTuple -> (Array[64][8], [128], [128])
+get_decrypt_output_and_tag
+  ( out
+  , prefetch9, prefetch8, prefetch7, prefetch6, prefetch5, prefetch4, prefetch3, prefetch2
+  , spill_Z3
+  , prefetch1, prefetch0
+  , inout5, inout4, inout3, inout2, inout1, inout0
+  , loop_Xi
+  , Z3
+  , Z0
+  , T1
+  , prefetch_offset, ctr_least_byte, loop_index
+  ) = (out, spill_Z3 ^ (drop loop_Xi) ^ (drop Z0), swap8 (drop T1))
+
+combine_Xi_parts : LoopTuple -> LoopTuple
+combine_Xi_parts
+  ( out
+  , prefetch9, prefetch8, prefetch7, prefetch6, prefetch5, prefetch4, prefetch3, prefetch2
+  , spill_Z3
+  , prefetch1, prefetch0
+  , inout5, inout4, inout3, inout2, inout1, inout0
+  , loop_Xi
+  , Z3
+  , Z0
+  , T1
+  , prefetch_offset, ctr_least_byte, loop_index
+  ) =
+    ( out
+    , prefetch9, prefetch8, prefetch7, prefetch6, prefetch5, prefetch4, prefetch3, prefetch2
+    , 0
+    , prefetch1, prefetch0
+    , inout5, inout4, inout3, inout2, inout1, inout0
+    , 0 # (spill_Z3 ^ (drop loop_Xi) ^ (drop Z0))
+    , Z3
+    , 0
+    , T1
+    , prefetch_offset, ctr_least_byte, loop_index
+    )
+
+loadHalfBlock : Array[64][8] -> [64] -> [64]
+loadHalfBlock arr idx = join (arrayRangeLookup arr idx)
+
+
+aes_encrypt_blocks_6_impl :
+  [32][8] ->
+  [64] ->
+  [512] ->
+  [512] ->
+  [512] ->
+  [512] ->
+  [512] ->
+  [512] ->
+  [512] ->
+  [6][128] ->
+  ([128], [6][128])
+aes_encrypt_blocks_6_impl key ctr_least_byte T1 inout0 inout1 inout2 inout3 inout4 inout5 [in_block0, in_block1, in_block2, in_block3, in_block4, in_block5] =
+  (next_T1, [out_block0, out_block1, out_block2, out_block3, out_block4, out_block5])
+ where
+  ctr_least_byte_overflow = (((0 : [1]) # (drop`{32} ctr_least_byte)) + (6 << 24)) <$ 0
+
+  next_T1 = if ctr_least_byte_overflow then inc_ctr T1 6 else ((drop`{384} inout5) + (1 << 120))
+
+  key_schedule = ExpandKey (join key)
+
+  out_block0 = in_block0
+             ^ (aesEncryptWithKeySchedule (swap8 ((drop inout0) ^ (join (reverse (take key))))) key_schedule)
+  out_block1 = in_block1
+             ^ (aesEncryptWithKeySchedule (swap8 (if ctr_least_byte_overflow then inc_ctr T1 1 else drop inout1)) key_schedule)
+  out_block2 = in_block2
+             ^ (aesEncryptWithKeySchedule (swap8 (if ctr_least_byte_overflow then inc_ctr T1 2 else drop inout2)) key_schedule)
+  out_block3 = in_block3
+             ^ (aesEncryptWithKeySchedule (swap8 (drop (if ctr_least_byte_overflow then inc_ctr' T1 3 else inout3))) key_schedule)
+  out_block4 = in_block4
+             ^ (aesEncryptWithKeySchedule (swap8 (drop (if ctr_least_byte_overflow then inc_ctr' T1 4 else inout4))) key_schedule)
+  out_block5 = in_block5
+             ^ (aesEncryptWithKeySchedule (swap8 (drop (if ctr_least_byte_overflow then inc_ctr' T1 5 else inout5))) key_schedule)
+
+inc_ctr : [512] -> [32] -> [128]
+inc_ctr ctr_iv i =
+  (join (split`{each=8} ((swap8 ((swap8 (take`{32} (drop`{384} ctr_iv))) + i)) # (drop`{416} ctr_iv))))
+
+inc_ctr' : [512] -> [32] -> [512]
+inc_ctr' ctr_iv i =
+  0 # (join (split`{each=8} ((swap8 ((swap8 (take`{32} (drop`{384} ctr_iv))) + i)) # (drop`{416} ctr_iv))))
+
+gcm_polyval_pmult3_impl : [32][8] -> [128] -> [128] -> [128] -> [6][128] -> ([128], [128], [128])
+gcm_polyval_pmult3_impl key Xi_part0 Xi_part1 Xi_part2 blks = (res_Xi_part0, res_Xi_part1, res_Xi_part2)
+  where
+    Htable = get_Htable key
+    Xi = Xi_part0 ^ Xi_part1 ^ Xi_part2
+
+    Xi_0 = gcm_polyval_mul_pmult3 (Htable @ 0) (blks @ 5)
+    Xi_1 = gcm_polyval_mul_pmult3 (Htable @ 1) (blks @ 4)
+    Xi_2 = gcm_polyval_mul_pmult3 (Htable @ 3) (blks @ 3)
+    Xi_3 = gcm_polyval_mul_pmult3 (Htable @ 4) (blks @ 2)
+    Xi_4 = gcm_polyval_mul_pmult3 (Htable @ 6) (blks @ 1)
+    Xi_5 = gcm_polyval_mul_pmult3 (Htable @ 7) (Xi ^ (blks @ 0))
+    Xi_6 = Xi_0 ^ Xi_1 ^ Xi_2 ^ Xi_3 ^ Xi_4 ^ Xi_5
+
+    x_225 = gcm_polyval_red_half_pmult (lo_bits Xi_6)
+
+    res_Xi_part0 = hi_bits Xi_6
+    res_Xi_part1 = (lo_bits x_225) # (hi_bits x_225)
+    res_Xi_part2 = (gcm_polyval_red_half_pmult x_225) ^ ((lo_bits x_225) # (hi_bits x_225))
+
+gcm_polyval_pmult4_impl : [32][8] -> [128] -> [128] -> [128] -> [6][128] -> ([128], [128], [128])
+gcm_polyval_pmult4_impl key Xi_part0 Xi_part1 Xi_part2 blks = (res_Xi_part0, res_Xi_part1, res_Xi_part2)
+  where
+    Htable = get_Htable key
+    Xi = Xi_part0 ^ Xi_part1 ^ Xi_part2
+
+    Xi_0 = gcm_polyval_mul_pmult4 (Htable @ 0) (blks @ 5)
+    Xi_1 = gcm_polyval_mul_pmult4 (Htable @ 1) (blks @ 4)
+    Xi_2 = gcm_polyval_mul_pmult4 (Htable @ 3) (blks @ 3)
+    Xi_3 = gcm_polyval_mul_pmult4 (Htable @ 4) (blks @ 2)
+    Xi_4 = gcm_polyval_mul_pmult4 (Htable @ 6) (blks @ 1)
+    Xi_5 = gcm_polyval_mul_pmult4 (Htable @ 7) (Xi ^ (blks @ 0))
+    Xi_6 = Xi_0 ^ Xi_1 ^ Xi_2 ^ Xi_3 ^ Xi_4 ^ Xi_5
+
+    x_225 = gcm_polyval_red_half_pmult (lo_bits Xi_6)
+
+    res_Xi_part0 = hi_bits Xi_6
+    res_Xi_part1 = (lo_bits x_225) # (hi_bits x_225)
+    res_Xi_part2 = (gcm_polyval_red_half_pmult x_225) ^ ((lo_bits x_225) # (hi_bits x_225))
+
+combine_Xi_triple : ([128], [128], [128]) -> [128]
+combine_Xi_triple (x, y, z) = x ^ y ^ z
+
+
+aesni_gcm_encrypt_impl_loop :
+  [64] ->
+  Array[64][8] ->
+  Array[64][8] ->
+  [32][8] ->
+  [12][8] ->
+  [4][8] ->
+  [16][8] ->
+  LoopTuple ->
+  LoopTuple
+aesni_gcm_encrypt_impl_loop len in out key ivec ctr Xi loop_tuple =
+  if 6 * (get_loop_index loop_tuple) + 24 <= len / 16
+    then
+      aesni_gcm_encrypt_impl_loop len in out key ivec ctr Xi
+        (aesni_gcm_encrypt_impl_loop_step len in out key ivec ctr Xi loop_tuple)
+    else
+      loop_tuple
+
+aesni_gcm_encrypt_impl_loop_step :
+  [64] ->
+  Array[64][8] ->
+  Array[64][8] ->
+  [32][8] ->
+  [12][8] ->
+  [4][8] ->
+  [16][8] ->
+  LoopTuple ->
+  LoopTuple
+aesni_gcm_encrypt_impl_loop_step len in out key ivec ctr Xi
+  ( loop_out
+  , prefetch9, prefetch8, prefetch7, prefetch6, prefetch5, prefetch4, prefetch3, prefetch2
+  , spill_Z3
+  , prefetch1, prefetch0
+  , inout5, inout4, inout3, inout2, inout1, inout0, loop_Xi, Z3, Z0, T1
+  , prefetch_offset, ctr_least_byte, loop_index
+  ) = ( arrayRangeUpdate loop_out (loop_index * 96 + 192) (split (join [out_block0, out_block1, out_block2, out_block3, out_block4, out_block5]))
+      , loadHalfBlock loop_out (next_prefetch_offset + 72)
+      , loadHalfBlock loop_out (next_prefetch_offset + 64)
+      , loadHalfBlock loop_out (next_prefetch_offset + 56)
+      , loadHalfBlock loop_out (next_prefetch_offset + 48)
+      , loadHalfBlock loop_out (next_prefetch_offset + 40)
+      , loadHalfBlock loop_out (next_prefetch_offset + 32)
+      , loadHalfBlock loop_out (next_prefetch_offset + 24)
+      , loadHalfBlock loop_out (next_prefetch_offset + 16)
+      , next_spill_Z3
+      , loadHalfBlock loop_out (next_prefetch_offset + 8)
+      , loadHalfBlock loop_out next_prefetch_offset
+      , 0 # (next_T1 + (5 << 120))
+      , 0 # (next_T1 + (4 << 120))
+      , 0 # (next_T1 + (3 << 120))
+      , 0 # (next_T1 + (2 << 120))
+      , 0 # (next_T1 + (1 << 120))
+      , 0 # (next_T1 ^ (join (reverse (take key))))
+      , 0 # next_loop_Xi
+      , 0 # (loadHalfBlock loop_out (next_prefetch_offset + 80)) # (loadHalfBlock loop_out (next_prefetch_offset + 88))
+      , 0 # next_Z0
+      // T1 == (swap8 ctr) # iv
+      , 0 # next_T1
+      , next_prefetch_offset
+      , 0 # ((drop`{32} ctr_least_byte) + (6 << 24))
+      , loop_index + 1
+      )
+ where
+  //next_prefetch_offset = prefetch_offset + (if prefetch_offset + 192 <= len then 96 else 0)
+  next_prefetch_offset = prefetch_offset + (if prefetch_offset + 4096 <= len + 3904 then 96 else 0)
+
+  [in_block0, in_block1, in_block2, in_block3, in_block4, in_block5] = split (join (arrayRangeLookup in (loop_index * 96 + 192)))
+  (next_T1, [out_block0, out_block1, out_block2, out_block3, out_block4, out_block5]) = aes_encrypt_blocks_6_impl key ctr_least_byte T1 inout0 inout1 inout2 inout3 inout4 inout5 [in_block0, in_block1, in_block2, in_block3, in_block4, in_block5]
+
+  enc_block0 = prefetch0 # prefetch1
+  enc_block1 = prefetch2 # prefetch3
+  enc_block2 = prefetch4 # prefetch5
+  enc_block3 = prefetch6 # prefetch7
+  enc_block4 = prefetch8 # prefetch9
+  enc_block5 = drop Z3
+  blocks = [enc_block0, enc_block1, enc_block2, enc_block3, enc_block4, enc_block5]
+  (next_spill_Z3, next_loop_Xi, next_Z0) = gcm_polyval_pmult4_impl key spill_Z3 (drop loop_Xi) (drop Z0) blocks
+
+
+aesni_gcm_decrypt_impl_loop :
+  [64] ->
+  Array[64][8] ->
+  Array[64][8] ->
+  [32][8] ->
+  [12][8] ->
+  [4][8] ->
+  [16][8] ->
+  LoopTuple ->
+  LoopTuple
+aesni_gcm_decrypt_impl_loop len in out key ivec ctr Xi loop_tuple =
+  if 6 * (get_loop_index loop_tuple) + 12 <= len / 16
+    then
+      aesni_gcm_decrypt_impl_loop len in out key ivec ctr Xi
+        (aesni_gcm_decrypt_impl_loop_step len in out key ivec ctr Xi loop_tuple)
+    else
+      loop_tuple
+
+aesni_gcm_decrypt_impl_loop_step :
+  [64] ->
+  Array[64][8] ->
+  Array[64][8] ->
+  [32][8] ->
+  [12][8] ->
+  [4][8] ->
+  [16][8] ->
+  LoopTuple ->
+  LoopTuple
+aesni_gcm_decrypt_impl_loop_step len in out key ivec ctr Xi
+  ( loop_out
+  , prefetch9, prefetch8, prefetch7, prefetch6, prefetch5, prefetch4, prefetch3, prefetch2
+  , spill_Z3
+  , prefetch1, prefetch0
+  , inout5, inout4, inout3, inout2, inout1, inout0, loop_Xi, Z3, Z0, T1
+  , prefetch_offset, ctr_least_byte, loop_index
+  ) = ( arrayRangeUpdate loop_out (loop_index * 96) (split (join [out_block0, out_block1, out_block2, out_block3, out_block4, out_block5]))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 72))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 64))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 56))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 48))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 40))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 32))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 24))
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 16))
+      , next_spill_Z3
+      , join (arrayRangeLookup`{n=8} in (next_prefetch_offset + 8))
+      , join (arrayRangeLookup`{n=8} in next_prefetch_offset)
+      , 0 # (next_T1 + (5 << 120))
+      , 0 # (next_T1 + (4 << 120))
+      , 0 # (next_T1 + (3 << 120))
+      , 0 # (next_T1 + (2 << 120))
+      , 0 # (next_T1 + (1 << 120))
+      , 0 # (next_T1 ^ (join (reverse (take key))))
+      , 0 # next_loop_Xi
+      , 0 # (join (arrayRangeLookup`{n=16} in (next_prefetch_offset + 80)))
+      , 0 # next_Z0
+      // T1 == (swap8 ((join iv) # ((join ctr) + (drop (6 * loop_index)))))
+      , 0 # next_T1
+      , next_prefetch_offset
+      , 0 # ((drop`{32} ctr_least_byte) + (6 << 24))
+      , loop_index + 1
+      )
+ where
+  //next_prefetch_offset = prefetch_offset + (if prefetch_offset + 192 <= len then 96 else 0)
+  next_prefetch_offset = prefetch_offset + (if prefetch_offset + 4096 <= len + 3904 then 96 else 0)
+
+  [in_block0, in_block1, in_block2, in_block3, in_block4, in_block5] = split (join (arrayRangeLookup in (loop_index * 96)))
+  (next_T1, [out_block0, out_block1, out_block2, out_block3, out_block4, out_block5]) = aes_encrypt_blocks_6_impl key ctr_least_byte T1 inout0 inout1 inout2 inout3 inout4 inout5 [in_block0, in_block1, in_block2, in_block3, in_block4, in_block5]
+
+  enc_block0 = prefetch0 # prefetch1
+  enc_block1 = prefetch2 # prefetch3
+  enc_block2 = prefetch4 # prefetch5
+  enc_block3 = prefetch6 # prefetch7
+  enc_block4 = prefetch8 # prefetch9
+  enc_block5 = drop Z3
+  blocks = [enc_block0, enc_block1, enc_block2, enc_block3, enc_block4, enc_block5]
+  (next_spill_Z3, next_loop_Xi, next_Z0) = gcm_polyval_pmult4_impl key spill_Z3 (drop loop_Xi) (drop Z0) blocks
+
+
+aesni_gcm_encrypt :
+  [64] ->
+  Array[64][8] ->
+  Array[64][8] ->
+  [32][8] ->
+  [12][8] ->
+  [4][8] ->
+  [16][8] ->
+  [64] ->
+  Array[64][8] ->
+  [128] ->
+  (Array[64][8], [128], [128])
+aesni_gcm_encrypt len in out key iv ctr Xi loop_index current_out current_Xi =
+  if loop_index < (len / 16) / 6
+    then aesni_gcm_encrypt len in out key iv ctr Xi (loop_index + 1) next_out next_Xi
+    else (current_out, current_Xi, (join iv) # ((join ctr) + (drop (6 * ((len / 16) / 6)))))
+ where
+  in_blocks = split (join (arrayRangeLookup`{n=96} in (loop_index * 96)))
+  out_blocks = aes_ctr32_encrypt_blocks (join key) (join iv) ((join ctr) + (drop (6 * loop_index))) in_blocks
+  next_out = arrayRangeUpdate current_out (loop_index * 96) (split (join out_blocks))
+  next_Xi = gcm_ghash_blocks (gcm_init_H (join (get_H' key))) current_Xi out_blocks
+
+aesni_gcm_decrypt :
+  [64] ->
+  Array[64][8] ->
+  Array[64][8] ->
+  [32][8] ->
+  [12][8] ->
+  [4][8] ->
+  [16][8] ->
+  [64] ->
+  Array[64][8] ->
+  [128] ->
+  (Array[64][8], [128], [128])
+aesni_gcm_decrypt len in out key iv ctr Xi loop_index current_out current_Xi =
+  if loop_index < (len / 16) / 6
+    then aesni_gcm_decrypt len in out key iv ctr Xi (loop_index + 1) next_out next_Xi
+    else (current_out, current_Xi, (join iv) # ((join ctr) + (drop (6 * ((len / 16) / 6)))))
+ where
+  in_blocks = split (join (arrayRangeLookup`{n=96} in (loop_index * 96)))
+  out_blocks = aes_ctr32_encrypt_blocks (join key) (join iv) ((join ctr) + (drop (6 * loop_index))) in_blocks
+  next_out = arrayRangeUpdate current_out (loop_index * 96) (split (join out_blocks))
+  next_Xi = gcm_ghash_blocks (gcm_init_H (join (get_H' key))) current_Xi in_blocks
+
+
+aes_ctr32_encrypt_blocks : {n} (fin n) => [256] -> [96] -> [32] -> [n][128] -> [n][128]
+aes_ctr32_encrypt_blocks key iv ctr blocks =
+  [aes_ctr32_encrypt_block key iv (ctr + i) blk | blk <- blocks | i <- [0 ...]]
+
+aes_ctr32_encrypt_block : [256] -> [96] -> [32] -> [128] -> [128]
+aes_ctr32_encrypt_block key iv ctr block = block ^ (aesEncrypt ((iv # ctr), key))
+
+gcm_ghash_blocks : {n} (fin n) => [128] -> [128] -> [n][128] -> [128]
+gcm_ghash_blocks H Xi blocks = foldl (gcm_ghash_block H) Xi blocks
+
+gcm_ghash_block : [128] -> [128] -> [128] -> [128]
+gcm_ghash_block H Xi block = gcm_polyval H (Xi ^ block)
+
+
+
+aes_ctr32_encrypt_blocks_array : [256] -> [96] -> [32] -> Array[64][8] -> [64] -> [64] -> Array[64][8] -> Array[64][8]
+aes_ctr32_encrypt_blocks_array key iv ctr in len i out =
+  if i < len then
+    aes_ctr32_encrypt_blocks_array key iv ctr in len (i + 1)
+      (arrayRangeUpdate out (i * 16)
+        (split (aes_ctr32_encrypt_block key iv (ctr + drop`{32} i)
+          (join (arrayRangeLookup in (i * 16))))))
+  else
+    out
+
+gcm_ghash_blocks_array : [128] -> Array[64][8] -> [64] -> [64] -> [128] -> [128]
+gcm_ghash_blocks_array H blocks len i Xi =
+  if i < len then
+    gcm_ghash_blocks_array H blocks len (i + 1)
+      (gcm_ghash_block H Xi (join (arrayRangeLookup blocks (i * 16))))
+  else
+    Xi
+
+
+aes_gcm_encrypt_update : AES_GCM_Ctx -> Array[64][8] -> [64] -> Array[64][8] -> (AES_GCM_Ctx, Array[64][8])
+aes_gcm_encrypt_update ctx in len out =
+  if ctx.len % 16 != 0 /\ (ctx.len % 16) + (0 # drop`{60} len) < 16 /\ len - (0 # drop`{60} len) == 0
+    then (res_ctx', res_out')
+    else (res_ctx, res_out)
+  where
+    EKi_pre = EKi ctx (drop ((ctx.len + 15) / 16))
+    (res_out', res_Xi') = aes_gcm_encrypt_update_bytes EKi_pre in 0 ((drop ctx.len) + (drop len)) (drop ctx.len) (out, ctx.Xi)
+    res_ctx' = { key = ctx.key, iv = ctx.iv, Xi = res_Xi', len = ctx.len + len }
+
+    (pre_out, pre_Xi) = aes_gcm_encrypt_update_bytes EKi_pre in 0 0 (drop ctx.len) (out, ctx.Xi)
+
+    idx' = (16 - (ctx.len % 16)) % 16
+    len' = len - idx'
+    (in', out', Xi') = if ctx.len % 16 != 0
+      then
+        ( arrayCopy (arrayConstant 0) 0 in idx' len'
+        , arrayCopy (arrayConstant 0) 0 pre_out idx' len'
+        , gcm_gmult (gcm_init_H (join (get_H ctx))) pre_Xi
+        )
+      else (in, out, ctx.Xi)
+    ctr' = split ((get_i ctx) + 2)
+
+    ((out_0'', Xi'', _), ctr'', bulk) = if 288 <= len'
+      then
+        ( aesni_gcm_encrypt len' in' out' ctx.key ctx.iv ctr' Xi' 0 out' (join Xi')
+        , (join ctr') + (drop (6 * ((len' / 16) / 6)))
+        , 96 * (len' / 96)
+        )
+      else
+        ((out', join Xi', 0), (join ctr'), 0)
+    out'' = if 0 < len'
+      then arrayCopy pre_out idx' out_0'' 0 len'
+      else pre_out
+    idx'' = idx' + bulk
+    len'' = len' - bulk
+
+    (out''', Xi''', idx''') = if 16 * (len'' / 16) != 0
+      then (out_0, Xi_0, idx'' + (16 * (len'' / 16)))
+        where
+          out_0 = arrayCopy
+            out''
+            idx''
+            (aes_ctr32_encrypt_blocks_array
+              (join ctx.key)
+              (join ctx.iv)
+              ctr''
+              (arrayCopy (arrayConstant 0) 0 in idx'' (16 * (len'' / 16)))
+              (len'' / 16)
+              0
+              (arrayCopy (arrayConstant 0) 0 out'' idx'' (16 * (len'' / 16))))
+            0
+            (16 * (len'' / 16))
+          Xi_0 = gcm_ghash_blocks_array
+            (gcm_init_H (join (get_H ctx)))
+            (arrayCopy (arrayConstant 0) 0 out_0 idx'' (16 * (len'' / 16)))
+            (len'' / 16)
+            0
+            Xi''
+      else (out'', Xi'', idx'')
+
+    EKi_post = EKi ctx (drop ((ctx.len + len + 15) / 16))
+    (res_out, res_Xi) = aes_gcm_encrypt_update_bytes EKi_post in idx''' ((drop ctx.len) + (drop len)) 0 (out''', split Xi''')
+
+    res_ctx = { key = ctx.key, iv = ctx.iv, Xi = res_Xi, len = ctx.len + len }
+
+aes_gcm_encrypt_update_bytes : [16][8] -> Array[64][8] -> [64] -> [4] -> [4] -> (Array[64][8], [16][8]) -> (Array[64][8], [16][8])
+aes_gcm_encrypt_update_bytes eki in offset n j (out, Xi) =
+  if j != n then
+    aes_gcm_encrypt_update_bytes eki in (offset + 1) n (j + 1)
+      ( arrayUpdate out offset enc_byte
+      , update Xi j ((Xi @ j) ^ enc_byte)
+      )
+  else (out, Xi)
+  where
+    enc_byte = (arrayLookup in offset) ^ (eki @ j)
+
+
+aes_gcm_decrypt_update : AES_GCM_Ctx -> Array[64][8] -> [64] -> Array[64][8] -> (AES_GCM_Ctx, Array[64][8])
+aes_gcm_decrypt_update ctx in len out =
+  if ctx.len % 16 != 0 /\ (ctx.len % 16) + (0 # drop`{60} len) < 16 /\ len - (0 # drop`{60} len) == 0
+    then (res_ctx', res_out')
+    else (res_ctx, res_out)
+  where
+    EKi_pre = EKi ctx (drop ((ctx.len + 15) / 16))
+    (res_out', res_Xi') = aes_gcm_decrypt_update_bytes EKi_pre in 0 ((drop ctx.len) + (drop len)) (drop ctx.len) (out, ctx.Xi)
+    res_ctx' = { key = ctx.key, iv = ctx.iv, Xi = res_Xi', len = ctx.len + len }
+
+    (pre_out, pre_Xi) = aes_gcm_decrypt_update_bytes EKi_pre in 0 0 (drop ctx.len) (out, ctx.Xi)
+
+    idx' = (16 - (ctx.len % 16)) % 16
+    len' = len - idx'
+    (in', out', Xi') = if ctx.len % 16 != 0
+      then
+        ( arrayCopy (arrayConstant 0) 0 in idx' len'
+        , arrayCopy (arrayConstant 0) 0 pre_out idx' len'
+        , gcm_gmult (gcm_init_H (join (get_H ctx))) pre_Xi
+        )
+      else (in, out, ctx.Xi)
+    ctr' = split ((get_i ctx) + 2)
+
+    ((out_0'', Xi'', _), ctr'', bulk) = if 96 <= len'
+      then
+        ( aesni_gcm_decrypt len' in' out' ctx.key ctx.iv ctr' Xi' 0 out' (join Xi')
+        , (join ctr') + (drop (6 * ((len' / 16) / 6)))
+        , 96 * (len' / 96)
+        )
+      else
+        ((out', join Xi', 0), (join ctr'), 0)
+    out'' = if 0 < len'
+      then arrayCopy pre_out idx' out_0'' 0 len'
+      else pre_out
+    idx'' = idx' + bulk
+    len'' = len' - bulk
+
+    (out''', Xi''', idx''') = if 16 * (len'' / 16) != 0
+      then (out_0, Xi_0, idx'' + (16 * (len'' / 16)))
+        where
+          out_0 = arrayCopy
+            out''
+            idx''
+            (aes_ctr32_encrypt_blocks_array
+              (join ctx.key)
+              (join ctx.iv)
+              ctr''
+              (arrayCopy (arrayConstant 0) 0 in idx'' (16 * (len'' / 16)))
+              (len'' / 16)
+              0
+              (arrayCopy (arrayConstant 0) 0 out'' idx'' (16 * (len'' / 16))))
+            0
+            (16 * (len'' / 16))
+          Xi_0 = gcm_ghash_blocks_array
+            (gcm_init_H (join (get_H ctx)))
+            (arrayCopy (arrayConstant 0) 0 in idx'' (16 * (len'' / 16)))
+            (len'' / 16)
+            0
+            Xi''
+      else (out'', Xi'', idx'')
+
+    EKi_post = EKi ctx (drop ((ctx.len + len + 15) / 16))
+    (res_out, res_Xi) = aes_gcm_decrypt_update_bytes EKi_post in idx''' ((drop ctx.len) + (drop len)) 0 (out''', split Xi''')
+
+    res_ctx = { key = ctx.key, iv = ctx.iv, Xi = res_Xi, len = ctx.len + len }
+
+aes_gcm_decrypt_update_bytes : [16][8] -> Array[64][8] -> [64] -> [4] -> [4] -> (Array[64][8], [16][8]) -> (Array[64][8], [16][8])
+aes_gcm_decrypt_update_bytes eki in offset n j (out, Xi) =
+  if j != n then
+    aes_gcm_decrypt_update_bytes eki in (offset + 1) n (j + 1)
+      ( arrayUpdate out offset (enc_byte ^ (eki @ j))
+      , update Xi j ((Xi @ j) ^ enc_byte)
+      )
+  else (out, Xi)
+  where
+    enc_byte = arrayLookup in offset
+

--- a/SAW/spec/AES/AES-GCM.cry
+++ b/SAW/spec/AES/AES-GCM.cry
@@ -85,8 +85,11 @@ gcm_ghash_block H Xi inp = split (gcm_polyval H ((join Xi) ^ (join inp)))
 /*
  * AES_GCM context specification helpers.
  */
-get_Htable : AES_GCM_Ctx -> [12][128]
-get_Htable ctx = gcm_init (get_H ctx)
+get_Htable : [32][8] -> [12][128]
+get_Htable key = gcm_init (get_H' key)
+
+get_H' : [32][8] -> [2][64]
+get_H' key = split (join (aes_hw_encrypt zero key))
 
 get_i : AES_GCM_Ctx -> [32]
 get_i ctx = drop ((ctx.len + 15) / 16)


### PR DESCRIPTION
Caveats
* `llvm_verify_fixpoint_x86` proves *partial correctness*, that is, the property is verified just for terminating executions of the target x86_64 function
* induction proofs for `cryptol` functions are in fact proofs just for the inputs on which the function evaluation terminates, for example, `\x -> f x == g x` means that `f x` is equal with `g x` when `f x` terminates; moreover, the induction principle is applied manually, by using `prove_theorem assume_unsat` to create a rewrite rule that is then used in it's own proof, after the function `f` is unfolded.
* `saw` branch (with submodules): https://github.com/GaloisInc/saw-script/tree/sygus2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

