### PR TITLE
Add attribute noinline to OPENSSL_malloc

### DIFF
--- a/SAW/patch/noinline-OPENSSL_malloc.patch
+++ b/SAW/patch/noinline-OPENSSL_malloc.patch
@@ -1,0 +1,12 @@
+diff --git a/crypto/mem.c b/crypto/mem.c
+index 7e58609c0..b92a0e555 100644
+--- a/crypto/mem.c
++++ b/crypto/mem.c
+@@ -187,6 +187,7 @@ static const uint8_t kBoringSSLBinaryTag[18] = {
+     0,
+ };
+ 
++__attribute__((noinline))
+ void *OPENSSL_malloc(size_t size) {
+   if (malloc_impl != NULL) {
+     assert(OPENSSL_memory_alloc == NULL);

--- a/SAW/scripts/x86_64/entrypoint_check.sh
+++ b/SAW/scripts/x86_64/entrypoint_check.sh
@@ -21,6 +21,7 @@ go env -w GOPROXY=direct
 apply_patch "rsa-encrypt"
 apply_patch "nomuxrsp"
 apply_patch "ec_GFp_nistp384_point_mul_public"
+apply_patch "noinline-OPENSSL_malloc"
 apply_patch "noinline-aes_gcm_from_cipher_ctx"
 apply_patch "noinline-bn_mod_add_words"
 apply_patch "noinline-bn_reduce_once_in_place"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

AWS-LC PR:  https://github.com/aws/aws-lc/pull/1440
Ticket: P118331723

This PR adds attribute noinline to function `OPENSSL_malloc`. This PR doesn't require coordinated merge.