### PR TITLE
Fix CMAKE_C/CXX_FLAGS overriding problem

### DIFF
--- a/NSym/scripts/build_aarch64.sh
+++ b/NSym/scripts/build_aarch64.sh
@@ -13,8 +13,6 @@ mkdir -p build_src/aarch64
 cd build_src/aarch64
 export LDFLAGS="-fuse-ld=lld"
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-      -DCMAKE_CXX_FLAGS="-ggdb" \
-      -DCMAKE_C_FLAGS="-ggdb" \
       -DBUILD_LIBSSL=OFF \
       -DKEEP_ASM_LOCAL_SYMBOLS=1 \
       -DCMAKE_TOOLCHAIN_FILE=../../scripts/build_aarch64.cmake \

--- a/SAW/scripts/aarch64/build_llvm.sh
+++ b/SAW/scripts/aarch64/build_llvm.sh
@@ -20,8 +20,8 @@ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
       -DCMAKE_C_FLAGS="-ggdb" \
       -DBUILD_LIBSSL=OFF \
       -DCMAKE_TOOLCHAIN_FILE=../../scripts/aarch64/build_llvm.cmake \
-      -DCMAKE_C_FLAGS="--target=${TARGET} -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu" \
-      -DCMAKE_CXX_FLAGS="--target=${TARGET} -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu" \
+      -DCMAKE_C_FLAGS="-ggdb --target=${TARGET} -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu" \
+      -DCMAKE_CXX_FLAGS="-ggdb --target=${TARGET} -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu" \
       -DCMAKE_ASM_FLAGS="--target=${TARGET} -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu" \
       -DCMAKE_CXX_LINK_FLAGS="-Wl,--unresolved-symbols=ignore-in-object-files -I/usr/aarch64-linux-gnu/include -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu"  \
       ../../../src


### PR DESCRIPTION
Ticket: V1372003520
AWS-LC PR: https://github.com/aws/aws-lc/pull/1538
Previous AWS-LC-verification PR: https://github.com/awslabs/aws-lc-verification/pull/146

1. Fixed the CMAKE_C/CXX_FLAGS overriding problem to enable `-ggdb` in SAW proofs for aarch64
2. Removing `-ggdb` flag from NSym build because NSym doesn't need debugging information; it is generally a good idea to have less custom flags

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

