### PR TITLE
Upgrade Z3 version used in the AES-GCM x86 proof

### DIFF
--- a/SAW/scripts/x86_64/docker_install_aes_gcm.sh
+++ b/SAW/scripts/x86_64/docker_install_aes_gcm.sh
@@ -5,7 +5,7 @@
 
 set -ex
 
-Z3_URL='https://github.com/Z3Prover/z3/releases/download/z3-4.8.14/z3-4.8.14-x64-glibc-2.31.zip'
+Z3_URL='https://github.com/Z3Prover/z3/releases/download/z3-4.13.0/z3-4.13.0-x64-glibc-2.31.zip'
 YICES_URL='https://yices.csl.sri.com/releases/2.6.2/yices-2.6.2-x86_64-pc-linux-gnu-static-gmp.tar.gz'
 
 mkdir -p /bin /deps


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

AWS-LC PR: https://github.com/aws/aws-lc/pull/1628
Ticket: V1413501242

