### PR TITLE
Flip back src submodule to be main of aws-lc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = hmac-precompute
-	url = https://github.com/fabrice102/aws-lc.git
+	branch = main
+	url = https://github.com/aws/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/Dockerfile.coq
+++ b/Dockerfile.coq
@@ -9,7 +9,7 @@ ARG GO_VERSION=1.20.1
 ARG GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update
-RUN apt-get install -y wget unzip git cmake clang llvm python3-pip libncurses5 opam libgmp-dev cabal-install 
+RUN apt-get install -y wget unzip git cmake clang llvm python3-pip libncurses5 opam libgmp-dev pkg-config cabal-install
 
 RUN wget "https://dl.google.com/go/${GO_ARCHIVE}" && tar -xvf $GO_ARCHIVE && \
    mkdir $GOROOT &&  mv go/* $GOROOT && rm $GO_ARCHIVE

--- a/NSym/scripts/install.sh
+++ b/NSym/scripts/install.sh
@@ -7,9 +7,9 @@ set -ex
 
 SAW_URL='https://saw-builds.s3.us-west-2.amazonaws.com/saw-0.9.0.99-2023-06-08-ab46c76e0-Linux-x86_64.tar.gz'
 C2A_URL='https://cryptol-air-interface.s3.us-west-2.amazonaws.com/cryptol-air-interface-2023-11-20-fd3447e-Linux-x86_64.tar.gz'
-ELF_URL='https://ocaml-elf-loader.s3.us-west-2.amazonaws.com/elf_loader-2023-11-09-c95cf1c-Linux_x86_64.tar.gz'
-OSI_URL='https://ocaml-smt-interface.s3.us-west-2.amazonaws.com/ocaml_smt_interface-2023-11-07-9654c87-Linux_x86_64.tar.gz'
-NSYM_URL='https://native-code-symbolic-simulator.s3.us-west-2.amazonaws.com/nsym-2023-11-09-ae32e4c-Linux_x86_64.tar.gz'
+ELF_URL='https://ocaml-elf-loader.s3.us-west-2.amazonaws.com/elf_loader-2024-07-22-c95cf1c-Linux_x86_64.tar.gz'
+OSI_URL='https://ocaml-smt-interface.s3.us-west-2.amazonaws.com/ocaml_smt_interface-2024-07-22-9654c87-Linux_x86_64.tar.gz'
+NSYM_URL='https://native-code-symbolic-simulator.s3.us-west-2.amazonaws.com/nsym-2024-07-22-ae32e4c-Linux_x86_64.tar.gz'
 
 mkdir -p /bin /deps
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Formal verification PR: https://github.com/awslabs/aws-lc-verification/pull/157
AWS-LC PR: https://github.com/aws/aws-lc/pull/1574
Ticket: P140828887

This PR flips src submodule to point to the main of AWS-LC. In addition, it fixes two CI failures. The coq CI run now requires a new dependency `pkg-config`. The nsym CI run now uses recompiled `ocaml-smt-interface`, `ocaml-elf-loader` and `nsym`.