### PR TITLE
Specify C99 as the standard when compiling AWS-LC until C11 atomics are modled

### DIFF
--- a/NSym/scripts/build_aarch64.sh
+++ b/NSym/scripts/build_aarch64.sh
@@ -13,6 +13,7 @@ mkdir -p build_src/aarch64
 cd build_src/aarch64
 export LDFLAGS="-fuse-ld=lld"
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+      -DCMAKE_C_STANDARD=99 \
       -DBUILD_LIBSSL=OFF \
       -DKEEP_ASM_LOCAL_SYMBOLS=1 \
       -DCMAKE_TOOLCHAIN_FILE=../../scripts/build_aarch64.cmake \

--- a/SAW/scripts/aarch64/build_llvm.sh
+++ b/SAW/scripts/aarch64/build_llvm.sh
@@ -16,6 +16,7 @@ export LLVM_COMPILER=clang
 export BINUTILS_TARGET_PREFIX=aarch64-linux-gnu
 
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+      -DCMAKE_C_STANDARD=99 \
       -DCMAKE_CXX_FLAGS="-ggdb" \
       -DCMAKE_C_FLAGS="-ggdb" \
       -DBUILD_LIBSSL=OFF \

--- a/SAW/scripts/x86_64/build_llvm.sh
+++ b/SAW/scripts/x86_64/build_llvm.sh
@@ -14,6 +14,6 @@ export CC=wllvm
 export CXX=clang++
 # The extern function __breakpoint__inv used in proof of ec_GFp_nistp384_point_mul_public is not defined
 # Option -DCMAKE_CXX_LINK_FLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" allows it
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="-ggdb" -DCMAKE_C_FLAGS="-ggdb" -DBUILD_LIBSSL=OFF -DCMAKE_CXX_LINK_FLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" ../../../src
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_STANDARD=99 -DCMAKE_CXX_FLAGS="-ggdb" -DCMAKE_C_FLAGS="-ggdb" -DBUILD_LIBSSL=OFF -DCMAKE_CXX_LINK_FLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS

--- a/SAW/scripts/x86_64/build_x86.sh
+++ b/SAW/scripts/x86_64/build_x86.sh
@@ -13,6 +13,6 @@ export CC=clang
 export CXX=clang++
 # The extern function __breakpoint__inv used in proof of ec_GFp_nistp384_point_mul_public is not defined
 # Option -DCMAKE_CXX_LINK_FLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" allows it
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="-ggdb" -DCMAKE_C_FLAGS="-ggdb" -DBUILD_LIBSSL=OFF -DCMAKE_CXX_LINK_FLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" ../../../src
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_STANDARD=99 -DCMAKE_CXX_FLAGS="-ggdb" -DCMAKE_C_FLAGS="-ggdb" -DBUILD_LIBSSL=OFF -DCMAKE_CXX_LINK_FLAGS="-Wl,--unresolved-symbols=ignore-in-object-files" ../../../src
 NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 make -j $NUM_CPU_THREADS


### PR DESCRIPTION
AWS-LC is migrating the default C standard from 99 to 11 in https://github.com/aws/aws-lc/pull/1729. With this change a new implementation of CRYPTO_refcount_inc based on C11 atomics is being introduced. Currently this C11 implementation is incompatible with the current `CRYPTO_refcount_inc_spec`.

```
"llvm_load_module" (/codebuild/output/src1734119689/src/github.com/aws/aws-lc-verification-build/SAW/proof/AES_KW/AES_KWP.saw:15:6-15:22)
Mismatched value types:
cmp value: ValIdent (Ident "4")
new value: ValIdent (Ident "7")
cmp type:  PrimType (Integer 32)
new type:  PrimType (Integer 32)
from:
	FUNC_CODE_INST_CMPXCHG
	@CRYPTO_refcount_inc
	FUNCTION_BLOCK
	FUNCTION_BLOCK_ID
	value symbol table
	MODULE_BLOCK
	Bitstream
```
From [AWS-LC CodeBuild public build log](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiWk5IUWJGRGxBcTJ2Mkp4WGF3dnBwYjc5V0ZZYSt5SVVGbkwvODkydTNTaVQ2V2FMN3hwa0tjSWNFemw2QWtCWW5welFWV3lpRFpKVitwejgvelhpRWh3NDNqcWhKalpPYW9hL2tLMDlJSDFPT1NkNyIsIml2UGFyYW1ldGVyU3BlYyI6Ilp4VXRNQXFGM1BZYVlaRkIiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D/build/e957053b-4fdc-47b0-b0b0-a51db40b7036)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

