### PR TITLE
Disabling the validation tests due to the refactor in EC

### DIFF
--- a/Dockerfile.coq
+++ b/Dockerfile.coq
@@ -21,7 +21,8 @@ RUN opam init --auto-setup --yes --disable-sandboxing \
    && opam repo add coq-released https://coq.inria.fr/opam/released \
    && opam install -y coq-bits \
    && opam install -y coq-itree.5.1.2 \
-   && opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#52c4868f1f65c7ce74e90000214de27e23ba98fb
+   && opam install -y coq-paco.4.2.0 \
+   && opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#d871d0af37ffee757e3be1f8d776bd7e84399712
 
 ADD SAW/scripts/x86_64 /lc/scripts
 RUN /lc/scripts/docker_install.sh

--- a/Dockerfile.coq
+++ b/Dockerfile.coq
@@ -21,8 +21,8 @@ RUN opam init --auto-setup --yes --disable-sandboxing \
    && opam repo add coq-released https://coq.inria.fr/opam/released \
    && opam install -y coq-bits \
    && opam install -y coq-itree.5.1.2 \
-   && opam install -y coq-paco.4.2.0 \
-   && opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#d871d0af37ffee757e3be1f8d776bd7e84399712
+   && opam pin -y coq-paco 4.2.0 \
+   && opam pin -y entree-specs https://github.com/GaloisInc/entree-specs.git#52c4868f1f65c7ce74e90000214de27e23ba98fb
 
 ADD SAW/scripts/x86_64 /lc/scripts
 RUN /lc/scripts/docker_install.sh

--- a/SAW/scripts/x86_64/entrypoint_check.sh
+++ b/SAW/scripts/x86_64/entrypoint_check.sh
@@ -16,8 +16,8 @@ apply_patch() {
 
 go env -w GOPROXY=direct
 
- # Start by patching in the constant validation tests and executing them
-apply_patch "p384_validate"
+# Start by patching in the constant validation tests and executing them
+# apply_patch "p384_validate"
 
 # Build in release mode
 
@@ -27,7 +27,7 @@ cp build_src/llvm_x86/crypto/crypto_test build/llvm_x86/crypto/crypto_test
 extract-bc build/llvm_x86/crypto/crypto_test
 
 # run the tests
-./build/llvm_x86/crypto/crypto_test
+# ./build/llvm_x86/crypto/crypto_test
 
 # Next check the SAW proofs
 

--- a/SAW/scripts/x86_64/entrypoint_check_aes_gcm.sh
+++ b/SAW/scripts/x86_64/entrypoint_check_aes_gcm.sh
@@ -16,8 +16,8 @@ apply_patch() {
 
 go env -w GOPROXY=direct
 
- # Start by patching in the constant validation tests and executing them
-apply_patch "p384_validate"
+# Start by patching in the constant validation tests and executing them
+# apply_patch "p384_validate"
 
 # Build in release mode
 
@@ -27,7 +27,7 @@ cp build_src/llvm_x86/crypto/crypto_test build/llvm_x86/crypto/crypto_test
 extract-bc build/llvm_x86/crypto/crypto_test
 
 # run the tests
-./build/llvm_x86/crypto/crypto_test
+# ./build/llvm_x86/crypto/crypto_test
 
 # Next check the SAW proofs
 


### PR DESCRIPTION
AWS-LC is currently undergone disruptive changes in EC curves. We have disabled EC related proofs to allow the changes to be made as is stated in ticket P136759315. We found another validation test that needs to be disabled due to the EC changes in a recent PR, therefore disabling it to allow EC refactoring. We will reenable this validation test and EC proofs once the refactoring is done.

Ticket: P169003436
AWS-LC PR: https://github.com/aws/aws-lc/pull/1720

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

