### PR TITLE
Add OPENSSL_cleanse override to AES-GCM SAW proofs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
-	branch = main
-	url = https://github.com/aws/aws-lc.git
+	branch = findings-zeroize
+	url = https://github.com/justsmth/aws-lc.git
 [submodule "cryptol-specs"]
 	path = cryptol-specs
 	branch = sha-imperative

--- a/SAW/proof/AES/AES-GCM.saw
+++ b/SAW/proof/AES/AES-GCM.saw
@@ -262,6 +262,7 @@ llvm_verify m "EVP_CIPHER_CTX_ctrl"
 // EVP_{Encrypt,Decrypt}Final_ex.
 let evp_cipher_ovs =
   [ OPENSSL_malloc_ov
+  , OPENSSL_cleanse_ov
   , aes_gcm_from_cipher_ctx_ov
   , aes_hw_set_encrypt_key_ov
   , aes_hw_encrypt_ov


### PR DESCRIPTION
### Related
* aws/aws-lc#3121

### Description
Add `OPENSSL_cleanse_ov` to the `evp_cipher_ovs` override list in the AES-GCM SAW proofs.

This is needed to support aws/aws-lc#3121, which adds `OPENSSL_cleanse` calls to zeroize sensitive stack buffers in several cryptographic functions. Two of those calls land on the `EVP_CipherInit_ex` proof path:

- `CRYPTO_gcm128_init_key` — cleansing the `ghash_key` (the raw GHASH subkey `H = AES_K(0^128)`)
- `CRYPTO_ghash_init` — cleansing the byte-swapped `H[2]` local copy of the same subkey

Without the override, SAW attempts to symbolically execute `OPENSSL_cleanse`, which contains an inline assembly barrier (`__asm__ __volatile__`) and cannot be interpreted, causing the `fv-saw-x86_64-aes-gcm` job to fail.

The `OPENSSL_cleanse_ov` override is already defined in `proof/common/memory.saw` (which `AES-GCM.saw` includes) and is already used by the ECDSA and ECDH proofs for the same reason.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

